### PR TITLE
Changing behavior when a CRL Cache exceeds its nextUpdate date. Curre…

### DIFF
--- a/components/validation/pom.xml
+++ b/components/validation/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>org.wso2.carbon.extension.identity.x509certificate.revocation</artifactId>
         <groupId>org.wso2.carbon.extension.identity.x509certificate</groupId>
-        <version>1.0.16-SNAPSHOT</version>
+        <version>1.0.6.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/CacheEntryUpdate.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/CacheEntryUpdate.java
@@ -1,0 +1,68 @@
+package org.wso2.carbon.identity.x509Certificate.validation;
+
+import java.io.IOException;
+import java.security.cert.X509CRL;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.x509Certificate.validation.cache.CRLCacheEntry;
+
+public class CacheEntryUpdate implements Runnable {
+	
+	private String crlURL;
+	private CRLCacheEntry cacheEntry;
+
+	private static final Log log = LogFactory.getLog(CacheEntryUpdate.class);
+	@Override
+	public void run() {
+		boolean doUpdate = false;
+		synchronized(cacheEntry) {  // Check if update is in progress. This is synchronized to make sure we have a singleton
+			if (!cacheEntry.isUpdateInProgress()) {
+				cacheEntry.setUpdateInProgress(true);
+				log.info("Starting CRL cache update for " + crlURL + " at " + System.currentTimeMillis());
+				doUpdate = true;
+			} else {
+				log.info("CRL cache update for " + crlURL + " already running. Not starting again");
+			}
+		}
+		if (doUpdate) {
+		X509CRL x509CRL = null;
+			try {
+				int retry = 0;
+				while (x509CRL == null && retry++ < 100 ) {
+					x509CRL = CertificateValidationUtil.downloadCRLFromWeb(crlURL, 1);  // Get the latest CRL
+					if (x509CRL == null) {
+						log.warn("Unable to update CRL for " + crlURL + " on attempt " + retry + ". Will try again in " + 5*retry + " seconds.");
+						try {
+							Thread.sleep(5000 * retry);
+						} catch (InterruptedException e) {
+							log.debug("Sleep interrupted");
+						}
+					}
+				}
+			} catch (IOException | CertificateValidationException e) {
+				e.printStackTrace();
+			}
+			if (x509CRL == null) {  
+				synchronized(cacheEntry) {  //Synchronize the setting of new CRL and release of the update in progress flag
+					cacheEntry.setUpdateInProgress(false);
+				}
+				log.error("Failed to cache update for " + crlURL );
+			} else {
+				synchronized(cacheEntry) {  //Synchronize the setting of new CRL and release of the update in progress flag
+					cacheEntry.setX509CRL(x509CRL);
+					cacheEntry.setUpdateInProgress(false);
+				}
+				log.info("Finished cache update for " + crlURL + " at " + System.currentTimeMillis());
+				
+			}
+		}
+	}
+
+	public CacheEntryUpdate(String crlURL, CRLCacheEntry cacheEntry) {
+		super();
+		this.crlURL = crlURL;
+		this.cacheEntry = cacheEntry;
+	}
+
+}

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/cache/CRLCacheEntry.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/cache/CRLCacheEntry.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.x509Certificate.validation.cache;
 
 import java.io.Serializable;
 import java.security.cert.X509CRL;
+import java.util.Date;
 
 /**
  * CRL cache entry with X509CRL.
@@ -29,6 +30,10 @@ public class CRLCacheEntry implements Serializable {
     private static final long serialVersionUID = 1591693579088522864L;
 
     private X509CRL x509CRL;
+    
+    private boolean updateInProgress = false;  // Used as key for Singleton Update flow
+    
+    private Date nextUpdate;  // In case CRL does not have nextUpdate, this will be used. Always set to 24 hours after setX509CRL is called.
 
     /**
      * Get X509 CRL.
@@ -48,5 +53,19 @@ public class CRLCacheEntry implements Serializable {
     public void setX509CRL(X509CRL x509CRL) {
 
         this.x509CRL = x509CRL;
+        nextUpdate = new Date(System.currentTimeMillis()+ (3600000));
     }
+
+	public boolean isUpdateInProgress() {
+		return updateInProgress;
+	}
+
+	public void setUpdateInProgress(boolean updateInProgress) {
+		this.updateInProgress = updateInProgress;
+	}
+
+	public Date getNextUpdate() {
+		return nextUpdate;
+	}
+
 }

--- a/components/valve/pom.xml
+++ b/components/valve/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>org.wso2.carbon.extension.identity.x509certificate.revocation</artifactId>
         <groupId>org.wso2.carbon.extension.identity.x509certificate</groupId>
-        <version>1.0.16-SNAPSHOT</version>
+        <version>1.0.6.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/features/validation/org.wso2.carbon.extension.identity.x509Certificate.validation.server.feature/pom.xml
+++ b/features/validation/org.wso2.carbon.extension.identity.x509Certificate.validation.server.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.extension.identity.x509certificate</groupId>
         <artifactId>x509certificate-validation-feature</artifactId>
-        <version>1.0.16-SNAPSHOT</version>
+        <version>1.0.6.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/validation/pom.xml
+++ b/features/validation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>org.wso2.carbon.extension.identity.x509certificate.revocation</artifactId>
         <groupId>org.wso2.carbon.extension.identity.x509certificate</groupId>
-        <version>1.0.16-SNAPSHOT</version>
+        <version>1.0.6.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.wso2.carbon.extension.identity.x509certificate</groupId>
     <artifactId>org.wso2.carbon.extension.identity.x509certificate.revocation</artifactId>
-    <version>1.0.16-SNAPSHOT</version>
+    <version>1.0.6.2</version>
     <packaging>pom</packaging>
     <name>WSO2 Carbon Extension - X509 Certificate Revocation</name>
     <url>http://wso2.org</url>


### PR DESCRIPTION
…nt behavior is to delete the cache object and start a new download. This has caused threading problems under load, which result in the CA no longer being used for CRL checking until the WSO2 service is restarted. New behavior leaves the cached CRL in place, and starts the reload as a Singleton Object. Then waits for up to 2 seconds for the new CRL to be downloaded. If it is not downloaded in 2 seconds, it will continue the CRL checking with the old cached CRL, so that at least older revoked certificates can be caught. The CRL download is managed by a new class, CacheEntryUpdate, which will retry with lengthening breaks between tries, until successful. Log entries should give adequate notice if there is a problem with CRL download.

## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.