### PR TITLE
Update Dependencies to IPK versions

### DIFF
--- a/components/valve/pom.xml
+++ b/components/valve/pom.xml
@@ -58,6 +58,11 @@
             <groupId>org.slf4j</groupId>
             <artifactId>log4j-over-slf4j</artifactId>
         </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -99,6 +104,10 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
                     </suiteXmlFiles>
+                    <classpathDependencyExcludes>
+                        <classpathDependencyExclude>org.wso2.org.ops4j.pax.logging</classpathDependencyExclude>
+                        <classpathDependencyExclude>org.ops4j.pax.logging</classpathDependencyExclude>
+                    </classpathDependencyExcludes>
                     <systemPropertyVariables>
                         <jacoco-agent.destfile>target/jacoco.exec</jacoco-agent.destfile>
                     </systemPropertyVariables>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
                 <version>${carbon.kernel.version}</version>
                 <exclusions>
                     <exclusion>
-                        <groupId>org.ops4j.pax.logging</groupId>
+                        <groupId>org.wso2.org.ops4j.pax.logging</groupId>
                         <artifactId>pax-logging-api</artifactId>
                     </exclusion>
                 </exclusions>
@@ -90,6 +90,12 @@
                 <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.identity.core</artifactId>
                 <version>${carbon.identity.framework.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.eclipse.equinox</groupId>
+                        <artifactId>javax.servlet</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.extension.identity.x509certificate</groupId>
@@ -124,6 +130,12 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>log4j-over-slf4j</artifactId>
                 <version>${slf4j.api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.servlet</groupId>
+                <artifactId>javax.servlet-api</artifactId>
+                <version>${javax.servlet-api.version}</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -207,8 +219,8 @@
     </build>
 
     <properties>
-        <carbon.identity.framework.version>5.11.148</carbon.identity.framework.version>
-        <carbon.identity.framework.imp.pkg.version.range>[5.0.0, 6.0.0)
+        <carbon.identity.framework.version>6.0.0</carbon.identity.framework.version>
+        <carbon.identity.framework.imp.pkg.version.range>[6.0.0, 7.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
         <carbon.kernel.version>4.6.1</carbon.kernel.version>
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
@@ -237,7 +249,7 @@
         <imp.pkg.version.javax.servlet>2.4.0</imp.pkg.version.javax.servlet>
         <imp.pkg.version.apache.tomcat>[7.0.0, 9.0.0)</imp.pkg.version.apache.tomcat>
         <slf4j.api.version>1.7.21</slf4j.api.version>
-
+        <javax.servlet-api.version>4.0.1</javax.servlet-api.version>
 
     </properties>
 </project>


### PR DESCRIPTION
The identity components are bumped to major versions created for IPK.

After the framework version bump, additional class `javax.servlet.http.PushBuilder` is needed for tests which is not available in the existing `javax.servlet` package from `org.eclipse.equinox`. Therefore the new `javax.servlet-api` dependency is added and in order to avoid signer conflicts with the existing servlet jar, the previous dependency is excluded.

Related issue: https://github.com/wso2-enterprise/identity-k8s-access-runtime/issues/16