### PR TITLE
Implement Proper Handling of Concurrent Requests in CRL Validation

### DIFF
--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/CertificateValidationUtil.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/CertificateValidationUtil.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -111,6 +111,7 @@ import static org.wso2.carbon.registry.core.RegistryConstants.PATH_SEPARATOR;
 
 public class CertificateValidationUtil {
     private static final String CONTENT_TYPE = "text/xml; charset=utf-8";
+    private static final String CRL_CACHE_SYNC_LOCK_PREFIX = "CRLCacheLock:";
 
     private static final Log log = LogFactory.getLog(CertificateValidationUtil.class);
 
@@ -594,16 +595,12 @@ public class CertificateValidationUtil {
                         if (log.isDebugEnabled()) {
                             log.debug("CRL is too old. Removing from cache.");
                         }
-                        CRLCache.getInstance().clearCacheEntry(crlUrl);
+                        clearCRLCache(crlUrl, peerCert);
                     }
                 }
 
-                x509CRL = downloadCRLFromWeb(crlUrl, retryCount, peerCert);
+                x509CRL = downloadCRLAndAddToCache(crlUrl, peerCert, retryCount);
                 if (x509CRL != null) {
-                    addCRLToCache(crlUrl, x509CRL);
-                    if (log.isDebugEnabled()) {
-                        log.debug("CRL is added into cache.");
-                    }
                     return getRevocationStatusFromCRL(x509CRL, peerCert);
                 }
             } catch (Exception e) {
@@ -641,8 +638,7 @@ public class CertificateValidationUtil {
         }
     }
 
-    private static boolean isValidX509CRLFromNextUpdate(X509CRL x509CRL, Date currentDate, Date nextUpdate)
-            throws CertificateValidationException {
+    private static boolean isValidX509CRLFromNextUpdate(X509CRL x509CRL, Date currentDate, Date nextUpdate) {
 
         if (nextUpdate != null) {
             if (log.isDebugEnabled()) {
@@ -652,8 +648,11 @@ public class CertificateValidationUtil {
             if (currentDate.before(x509CRL.getNextUpdate())) {
                 return true;
             } else {
-                throw new CertificateValidationException("X509 CRL is not valid. Next update date: " +
-                        nextUpdate.toString() + " is before the current date: " + currentDate.toString());
+                if (log.isDebugEnabled()) {
+                    log.debug("X509 CRL is not valid. Next update date: " +
+                            nextUpdate.toString() + " is before the current date: " + currentDate.toString());
+                }
+                return false;
             }
         } else {
             if (log.isDebugEnabled()) {
@@ -661,6 +660,38 @@ public class CertificateValidationUtil {
             }
         }
         return false;
+    }
+
+    private static void clearCRLCache(String crlUrl, X509Certificate peerCert) throws CertificateValidationException {
+
+        synchronized ((CRL_CACHE_SYNC_LOCK_PREFIX + crlUrl).intern()) {
+            X509CRL x509CRL = getCRLFromCache(crlUrl);
+            if (x509CRL != null && !isValidX509Crl(x509CRL, peerCert)) {
+                CRLCache.getInstance().clearCacheEntry(crlUrl);
+            }
+        }
+    }
+
+    private static X509CRL downloadCRLAndAddToCache(
+            String crlUrl, X509Certificate peerCert, int retryCount)
+            throws CertificateValidationException, IOException {
+
+        X509CRL x509CRL;
+        synchronized ((CRL_CACHE_SYNC_LOCK_PREFIX + crlUrl).intern()) {
+            X509CRL x509CRLFromCache = getCRLFromCache(crlUrl);
+            if (x509CRLFromCache == null || !isValidX509Crl(x509CRLFromCache, peerCert)) {
+                x509CRL = downloadCRLFromWeb(crlUrl, retryCount, peerCert);
+                if (x509CRL != null) {
+                    addCRLToCache(crlUrl, x509CRL);
+                    if (log.isDebugEnabled()) {
+                        log.debug("CRL, downloaded from URL: " + crlUrl + ", is added into cache.");
+                    }
+                }
+            } else {
+                x509CRL = x509CRLFromCache;
+            }
+        }
+        return x509CRL;
     }
 
     private static X509CRL downloadCRLFromWeb(String crlURL, int retryCount, X509Certificate peerCert)

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/CertificateValidationUtil.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/CertificateValidationUtil.java
@@ -599,7 +599,7 @@ public class CertificateValidationUtil {
                     }
                 }
 
-                x509CRL = downloadCRLAndAddToCache(crlUrl, peerCert, retryCount);
+                x509CRL = downloadCRLAndAddToCache(crlUrl, retryCount, peerCert);
                 if (x509CRL != null) {
                     return getRevocationStatusFromCRL(x509CRL, peerCert);
                 }
@@ -673,7 +673,7 @@ public class CertificateValidationUtil {
     }
 
     private static X509CRL downloadCRLAndAddToCache(
-            String crlUrl, X509Certificate peerCert, int retryCount)
+            String crlUrl, int retryCount, X509Certificate peerCert)
             throws CertificateValidationException, IOException {
 
         X509CRL x509CRL;


### PR DESCRIPTION
### Purpose
- This PR fixes the following issues.
    1. Improper handling of concurrent requests in CRL validation
    2. The following issue with cached CRL expiry.
        - If the CRL in the cache is expired, it will not be cleared and renewed due to the reason that the method `isValidX509Crl` [1] does not return false when the CRL is expired [2]. Instead it throws an error and thus, the cache will not be cleared until the cache is invalidated after the invalidation time or until you restart the error.

### Related Issues
- https://github.com/wso2/product-is/issues/19569

[1] - https://github.com/wso2-extensions/identity-x509-commons/blob/887aab9e8f88af52f54332d2ff7bd2ebd1dbea1d/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/CertificateValidationUtil.java#L588
[2] - https://github.com/wso2-extensions/identity-x509-commons/blob/887aab9e8f88af52f54332d2ff7bd2ebd1dbea1d/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/CertificateValidationUtil.java#L655