### PR TITLE
Fix OCSP validation fails with java.lang.IllegalArgumentException

### DIFF
--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/CertificateValidationUtil.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/CertificateValidationUtil.java
@@ -114,7 +114,7 @@ import static org.wso2.carbon.registry.core.RegistryConstants.PATH_SEPARATOR;
  * This class holds the X509 Certificate validation utilities.
  */
 public class CertificateValidationUtil {
-    private static final String CONTENT_TYPE = "text/xml; charset=utf-8";
+
     private static final String CRL_CACHE_SYNC_LOCK_PREFIX = "CRLCacheLock:";
 
     private static final Log log = LogFactory.getLog(CertificateValidationUtil.class);
@@ -1034,7 +1034,7 @@ public class CertificateValidationUtil {
         httpPost.addHeader(X509CertificateValidationConstants.HTTP_ACCEPT,
                 X509CertificateValidationConstants.HTTP_ACCEPT_OCSP);
 
-        httpPost.setEntity(new ByteArrayEntity(message, ContentType.create(CONTENT_TYPE)));
+        httpPost.setEntity(new ByteArrayEntity(message, ContentType.create("text/xml", "UTF-8")));
     }
 
     private static RevocationStatus getRevocationStatusFromOCSP(SingleResp resp)


### PR DESCRIPTION
## Purpose
> This PR fixes $subject by replacing the Content type create function from `create(String mimeType)`[1] to `create(String mimeType, String charset)`[2].

Related issues:
- https://github.com/wso2/product-is/issues/20019

[1] https://github.com/apache/httpcomponents-core/blob/a5c117028b7c620974304636d52f06f172f1d08b/httpcore/src/main/java/org/apache/http/entity/ContentType.java#L241
[2] https://github.com/apache/httpcomponents-core/blob/a5c117028b7c620974304636d52f06f172f1d08b/httpcore/src/main/java/org/apache/http/entity/ContentType.java#L227-L231