### PR TITLE
Add read timeout when downloading CRLs

### DIFF
--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/CertificateValidationUtil.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/CertificateValidationUtil.java
@@ -172,6 +172,9 @@ public class CertificateValidationUtil {
         }
     }
 
+    /**
+     * Load CRL download timeout from configuration.
+     */
     public static void loadCRLDownloadTimeoutFromConfig() {
 
         String cRLDownloadTimeoutStr = (String) IdentityConfigParser.getInstance().getConfiguration()

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/internal/X509CertificateValidationServiceComponent.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/internal/X509CertificateValidationServiceComponent.java
@@ -50,6 +50,7 @@ public class X509CertificateValidationServiceComponent {
         context.getBundleContext().registerService(RevocationValidationManager.class.getName(),
                 new RevocationValidationManagerImpl(), null);
         CertificateValidationUtil.addDefaultValidationConfigInRegistry(null);
+        CertificateValidationUtil.loadCRLDownloadTimeoutFromConfig();
         context.getBundleContext().registerService(RevocationValidator.class.getName(),
                 new CRLValidator(), null);
         context.getBundleContext().registerService(RevocationValidator.class.getName(),

--- a/components/valve/src/main/java/org/wso2/carbon/extension/identity/x509Certificate/valve/config/X509ServerConfiguration.java
+++ b/components/valve/src/main/java/org/wso2/carbon/extension/identity/x509Certificate/valve/config/X509ServerConfiguration.java
@@ -79,11 +79,10 @@ public class X509ServerConfiguration {
     private void parseX509ServerConfigurations(OMElement x509Elem) {
 
         // Get the configured name of the X509Request header.
-        String requestHeaderName =
-                x509Elem.getFirstChildWithName(getQNameWithIdentityNS(CONFIG_ELEM_X509_REQUEST_HEADER))
-                        .getText().trim();
+        OMElement requestHeaderName =
+                x509Elem.getFirstChildWithName(getQNameWithIdentityNS(CONFIG_ELEM_X509_REQUEST_HEADER));
         if (requestHeaderName != null) {
-            x509requestHeader = requestHeaderName;
+            x509requestHeader = requestHeaderName.getText().trim();
         }
     }
 


### PR DESCRIPTION
## Purpose
- Add read timeout when downloading CRLs
- Throw a certificate validation exception when downloaded CRL is not valid

## Related Issue
- https://github.com/wso2/product-is/issues/19569