### PR TITLE
Remove throwing CertificateValidationException

### DIFF
--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/CertificateValidationUtil.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/CertificateValidationUtil.java
@@ -502,8 +502,8 @@ public class CertificateValidationUtil {
     }
 
     private static void addDefaultCACertificateInRegistry(Registry registry, String caCertRegPath,
-                                                          X509Certificate certificate, OMElement validatorChildElement)
-            throws CertificateValidationException {
+                                                          X509Certificate certificate,
+                                                          OMElement validatorChildElement) {
 
         List<String> ocspUrls = new ArrayList<>();
         List<String> crlUrls = new ArrayList<>();


### PR DESCRIPTION
## Purpose
Remove the throwing of CertificateValidationException. Instead, all encountered errors will be logged.

### Related Issues
- https://github.com/wso2/product-is/issues/20172

### Related PRs
- https://github.com/wso2-extensions/identity-x509-commons/pull/37