### PR TITLE
Remove Registry Usages

### DIFF
--- a/components/validation/pom.xml
+++ b/components/validation/pom.xml
@@ -64,6 +64,10 @@
             <groupId>org.wso2.orbit.org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/validation/pom.xml
+++ b/components/validation/pom.xml
@@ -36,15 +36,19 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon</groupId>
-            <artifactId>org.wso2.carbon.registry.core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon</groupId>
             <artifactId>org.wso2.carbon.utils</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.application.common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.configuration.mgt.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.certificate.management</artifactId>
         </dependency>
 
         <dependency>
@@ -94,6 +98,18 @@
                             org.wso2.carbon.identity.application.common.*;
                             version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.core.util;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.configuration.mgt.core;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.configuration.mgt.core.exception;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.configuration.mgt.core.model;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.certificate.management.exception;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.certificate.management.service;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.certificate.management.model;
                             version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.bouncycastle.*;resolution:=optional,
                             *;resolution:=optional

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/X509CertificateValidationConstants.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/X509CertificateValidationConstants.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2018-2025, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -23,6 +23,9 @@ package org.wso2.carbon.identity.x509Certificate.validation;
  */
 public class X509CertificateValidationConstants {
 
+    public static final String VALIDATOR_CONF_RESOURCE_PREFIX = "certificate/validator/";
+    public static final String VALIDATOR_RESOURCE_TYPE = "Validator";
+    public static final String CERT_ID = "certId";
     public static final String CERT_VALIDATION_CONF_DIRECTORY = "security";
     public static final String CERT_VALIDATION_CONF_FILE = "certificate-validation.xml";
     public static final String VALIDATOR_CONF = "Validators";

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/X509CertificateValidationConstants.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/X509CertificateValidationConstants.java
@@ -23,9 +23,11 @@ package org.wso2.carbon.identity.x509Certificate.validation;
  */
 public class X509CertificateValidationConstants {
 
-    public static final String VALIDATOR_CONF_RESOURCE_PREFIX = "certificate/validator/";
+    public static final String X509_CA_CERT_FILE = "X509_CA_CERT_FILE";
+    public static final String X509_CERT_PREFIX = "X509_CERT_";
     public static final String VALIDATOR_RESOURCE_TYPE = "Validator";
-    public static final String CERT_ID = "certId";
+    public static final String X509_CA_CERT_ALIAS = "X509_CA";
+    public static final String CERTS = "CERTS";
     public static final String CERT_VALIDATION_CONF_DIRECTORY = "security";
     public static final String CERT_VALIDATION_CONF_FILE = "certificate-validation.xml";
     public static final String VALIDATOR_CONF = "Validators";

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/internal/CertValidationDataHolder.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/internal/CertValidationDataHolder.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2018-2025, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -18,7 +18,8 @@
 
 package org.wso2.carbon.identity.x509Certificate.validation.internal;
 
-import org.wso2.carbon.registry.core.service.RegistryService;
+import org.wso2.carbon.identity.certificate.management.service.CertificateManagementService;
+import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.user.core.service.RealmService;
 
 /**
@@ -26,9 +27,10 @@ import org.wso2.carbon.user.core.service.RealmService;
  */
 public class CertValidationDataHolder {
 
-    private static RegistryService registryService;
     private static RealmService realmService;
     private static CertValidationDataHolder instance = new CertValidationDataHolder();
+    private ConfigurationManager configurationManager;
+    private CertificateManagementService certificateManagementService;
 
     private CertValidationDataHolder() {
     }
@@ -44,23 +46,43 @@ public class CertValidationDataHolder {
     }
 
     /**
-     * Get registry service.
+     * Set Configuration Manager.
      *
-     * @return registry service
+     * @param configurationManager configuration manager
      */
-    public RegistryService getRegistryService() {
+    public void setConfigurationManager(ConfigurationManager configurationManager) {
 
-        return registryService;
+        this.configurationManager = configurationManager;
     }
 
     /**
-     * Set registry service.
+     * Get Configuration Manager.
      *
-     * @param service registry service
+     * @return configuration manager
      */
-    public void setRegistryService(RegistryService service) {
+    public ConfigurationManager getConfigurationManager() {
 
-        this.registryService = service;
+        return configurationManager;
+    }
+
+    /**
+     * Set Certificate Management Service.
+     *
+     * @param service certificate management service
+     */
+    public void setCertificateManagementService(CertificateManagementService service) {
+
+        this.certificateManagementService = service;
+    }
+
+    /**
+     * Get Certificate Management Service.
+     *
+     * @return certificate management service
+     */
+    public CertificateManagementService getCertificateManagementService() {
+
+        return certificateManagementService;
     }
 
     /**

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/internal/TenantManagementListener.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/internal/TenantManagementListener.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2018-2025, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -66,7 +66,7 @@ public class TenantManagementListener implements TenantMgtListener {
         String tenantDomain = IdentityTenantUtil.getTenantDomain(tenantId);
         carbonContext.setTenantId(tenantId);
         carbonContext.setTenantDomain(tenantDomain);
-        CertificateValidationUtil.addDefaultValidationConfigInRegistry(tenantDomain);
+        CertificateValidationUtil.addDefaultValidationConfigInRegistry();
         PrivilegedCarbonContext.endTenantFlow();
     }
 

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/model/CertObject.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/model/CertObject.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.wso2.carbon.identity.x509Certificate.validation.model;
+
+import java.util.List;
+
+public class CertObject {
+    private List<String> crlUrls;
+    private List<String> ocspUrls;
+    private String certId;
+    private String serialNumber;
+
+    // Getters and Setters
+    public List<String> getCrlUrls() {
+        return crlUrls;
+    }
+
+    public void setCrlUrls(List<String> crlUrls) {
+        this.crlUrls = crlUrls;
+    }
+
+    public List<String> getOcspUrls() {
+        return ocspUrls;
+    }
+
+    public void setOcspUrls(List<String> ocspUrls) {
+        this.ocspUrls = ocspUrls;
+    }
+
+    public String getCertId() {
+        return certId;
+    }
+
+    public void setCertId(String certId) {
+        this.certId = certId;
+    }
+
+    public String getSerialNumber() {
+        return serialNumber;
+    }
+
+    public void setSerialNumber(String serialNumber) {
+        this.serialNumber = serialNumber;
+    }
+
+    @Override
+    public String toString() {
+        return "CertObject{" +
+                "crlUrls=" + crlUrls +
+                ", ocspUrls=" + ocspUrls +
+                ", certId='" + certId + '\'' +
+                ", serialNumber='" + serialNumber + '\'' +
+                '}';
+    }
+}

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/model/IssuerDNMap.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/model/IssuerDNMap.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.wso2.carbon.identity.x509Certificate.validation.model;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class IssuerDNMap {
+    private Map<String, List<CertObject>> issuerCertMap = new HashMap<>();
+
+    public Map<String, List<CertObject>> getIssuerCertMap() {
+        return issuerCertMap;
+    }
+
+    public void setIssuerCertMap(Map<String, List<CertObject>> issuerCertMap) {
+        this.issuerCertMap = issuerCertMap;
+    }
+
+    @Override
+    public String toString() {
+        return "IssuerDNMap{" +
+                "issuerCertMap=" + issuerCertMap +
+                '}';
+    }
+}

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/model/ModelSerializer.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/model/ModelSerializer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.wso2.carbon.identity.x509Certificate.validation.model;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class ModelSerializer {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public static String serializeIssuerDNMap(IssuerDNMap issuerDNMap) throws JsonProcessingException {
+        return objectMapper.writeValueAsString(issuerDNMap);
+    }
+
+    public static IssuerDNMap deserializeIssuerDNMap(String json) throws Exception {
+        return objectMapper.readValue(json, IssuerDNMap.class);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -56,23 +56,22 @@
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon</groupId>
-                <artifactId>org.wso2.carbon.registry.core</artifactId>
-                <version>${carbon.kernel.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.ops4j.pax.logging</groupId>
-                        <artifactId>pax-logging-api</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.wso2.carbon</groupId>
                 <artifactId>org.wso2.carbon.utils</artifactId>
                 <version>${carbon.kernel.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.identity.application.common</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.configuration.mgt.core</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.certificate.management</artifactId>
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
             <dependency>
@@ -212,7 +211,7 @@
     </build>
 
     <properties>
-        <carbon.identity.framework.version>5.11.148</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.7.103</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.0.0, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
         <carbon.kernel.version>4.10.22</carbon.kernel.version>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,11 @@
                 <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
                 <version>${apache.felix.scr.ds.annotations.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson.databind.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>org.wso2.eclipse.osgi</groupId>
@@ -241,6 +246,7 @@
         <imp.pkg.version.javax.servlet>2.4.0</imp.pkg.version.javax.servlet>
         <imp.pkg.version.apache.tomcat>[7.0.0, 9.0.0)</imp.pkg.version.apache.tomcat>
         <slf4j.api.version>1.7.21</slf4j.api.version>
+        <jackson.databind.version>2.15.2</jackson.databind.version>
 
 
     </properties>


### PR DESCRIPTION
### Purpose
- Remove registry usage from the components.
- Will deprecate the existing public methods and add new methods for implementation.
- A different approach will be implemented to persist the certificates in the config store.

This pull request includes several updates related to dependency management, copyright information, and internal service handling.

### Dependency Management:
* Removed `org.wso2.carbon.registry.core` dependency from `components/validation/pom.xml` and `pom.xml`. [[1]](diffhunk://#diff-891eb748ec8b82059e5b14c4ec092b4a3f482b517191db861fb115ea41139a85L37-L40) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L57-L67)
* Added new dependencies for `org.wso2.carbon.identity.configuration.mgt.core` and `org.wso2.carbon.identity.certificate.management` in `components/validation/pom.xml` and `pom.xml`. [[1]](diffhunk://#diff-891eb748ec8b82059e5b14c4ec092b4a3f482b517191db861fb115ea41139a85R45-R52) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R67-R76)

### Internal Services:
* Updated `CertValidationDataHolder` to include `ConfigurationManager` and `CertificateManagementService` services.
* Modified `X509CertificateValidationServiceComponent` to set and unset `ConfigurationManager` and `CertificateManagementService` services. [[1]](diffhunk://#diff-7ef2ca95652ce91bd9610d39fe04378a1c3d60733e9d055d7178f6c7b1a974f3R71-R97) [[2]](diffhunk://#diff-7ef2ca95652ce91bd9610d39fe04378a1c3d60733e9d055d7178f6c7b1a974f3R122-R150)

### Miscellaneous:
* Updated copyright information across multiple files:
  * `X509CertificateValidationConstants.java`
  * `CertValidationDataHolder.java`
  * `TenantManagementListener.java`
  * `X509CertificateValidationServiceComponent.java`
* Added new constants in `X509CertificateValidationConstants.java`.
* Modified method `addDefaultValidationConfigInRegistry` to remove the `tenantDomain` parameter. [[1]](diffhunk://#diff-adc0813e64e79e5c2398e0c52095b2dceac4cddf37fc75280ef0c8aacc97e1e5L69-R69) [[2]](diffhunk://#diff-7ef2ca95652ce91bd9610d39fe04378a1c3d60733e9d055d7178f6c7b1a974f3L52-R53)