### PR TITLE
Add capability maintain x509 validation configs and certs in config store

### DIFF
--- a/components/validation/pom.xml
+++ b/components/validation/pom.xml
@@ -63,6 +63,10 @@
             <groupId>org.wso2.orbit.org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/validation/pom.xml
+++ b/components/validation/pom.xml
@@ -46,7 +46,10 @@
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.application.common</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.configuration.mgt.core</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
@@ -95,6 +98,12 @@
                             version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.core.util;
                             version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.configuration.mgt.core;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.configuration.mgt.core.exception;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.configuration.mgt.core.model;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.bouncycastle.*;resolution:=optional,
                             *;resolution:=optional
                         </Import-Package>
@@ -104,5 +113,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/CertificateValidationUtil.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/CertificateValidationUtil.java
@@ -458,7 +458,7 @@ public class CertificateValidationUtil {
             if (log.isDebugEnabled()) {
                 log.debug("CA certificate registry full path: " + caRegPath);
             }
-            caCertificateList = getCACertsFromRegResource(getNormalizedName(peerCertificate.getIssuerDN().getName()));
+            caCertificateList = getCACertsFromConfigStore(getNormalizedName(peerCertificate.getIssuerDN().getName()));
         } catch (UnsupportedEncodingException | ConfigurationManagementException e) {
             throw new CertificateValidationException("Error while loading CA certificates from registry in:" +
                     caRegPath, e);
@@ -500,7 +500,7 @@ public class CertificateValidationUtil {
                 replaceAll("%", ":");
     }
 
-    private static List<CACertificate> getCACertsFromRegResource(String issuerDN) throws
+    private static List<CACertificate> getCACertsFromConfigStore(String issuerDN) throws
             ConfigurationManagementException, CertificateValidationException {
 
         org.wso2.carbon.identity.configuration.mgt.core.model.Resource resource = CertValidationDataHolder.getInstance()

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/CertificateValidationUtil.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/CertificateValidationUtil.java
@@ -1331,16 +1331,6 @@ public class CertificateValidationUtil {
         }
     }
 
-    private static void addValidatorConfigInRegistry(String validatorConfRegPath,
-                                                     Validator validator) throws ConfigurationManagementException {
-
-        // Build a new resource from the validator configuration.
-        org.wso2.carbon.identity.configuration.mgt.core.model.Resource newResource =
-                buildResourceFromValidator(validator, getNormalizedName(validator.getDisplayName()),
-                        validatorConfRegPath);
-        addResource(newResource);
-    }
-
     /**
      * Method to add a resource.
      *

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/X509CertificateValidationConstants.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/X509CertificateValidationConstants.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2018-2025, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -23,6 +23,7 @@ package org.wso2.carbon.identity.x509Certificate.validation;
  */
 public class X509CertificateValidationConstants {
 
+    public static final String VALIDATOR_RESOURCE_TYPE = "Validator";
     public static final String CERT_VALIDATION_CONF_DIRECTORY = "security";
     public static final String CERT_VALIDATION_CONF_FILE = "certificate-validation.xml";
     public static final String VALIDATOR_CONF = "Validators";
@@ -51,6 +52,6 @@ public class X509CertificateValidationConstants {
     public static final String HTTP_ACCEPT_OCSP = "application/ocsp-response";
 
     private X509CertificateValidationConstants() {
-    }
 
+    }
 }

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/X509CertificateValidationConstants.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/X509CertificateValidationConstants.java
@@ -24,6 +24,10 @@ package org.wso2.carbon.identity.x509Certificate.validation;
 public class X509CertificateValidationConstants {
 
     public static final String VALIDATOR_RESOURCE_TYPE = "Validator";
+    public static final String X509_CA_CERT_FILE = "X509_CA_CERT_FILE";
+    public static final String X509_CERT_PREFIX = "X509_CERT_";
+    public static final String X509_CA_CERT_ALIAS = "X509_CA";
+    public static final String CERTS = "CERTS";
     public static final String CERT_VALIDATION_CONF_DIRECTORY = "security";
     public static final String CERT_VALIDATION_CONF_FILE = "certificate-validation.xml";
     public static final String VALIDATOR_CONF = "Validators";

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/X509CertificateValidationConstants.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/X509CertificateValidationConstants.java
@@ -23,10 +23,10 @@ package org.wso2.carbon.identity.x509Certificate.validation;
  */
 public class X509CertificateValidationConstants {
 
-    public static final String VALIDATOR_RESOURCE_TYPE = "x509-validators";
+    public static final String VALIDATOR_RESOURCE_TYPE = "X509_VALIDATOR";
     public static final String X509_CA_CERT_FILE = "x509_ca_cert_file";
     public static final String X509_CERT_PREFIX = "X509_CERT_";
-    public static final String X509_CA_CERT_ALIAS = "X509_CA";
+    public static final String X509_CA_CERT_RESOURCE_TYPE = "X509_REVOCATION_VALIDATION_CA";
     public static final String CERTS = "CERTS";
     public static final String CERT_VALIDATION_CONF_DIRECTORY = "security";
     public static final String CERT_VALIDATION_CONF_FILE = "certificate-validation.xml";

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/X509CertificateValidationConstants.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/X509CertificateValidationConstants.java
@@ -23,8 +23,8 @@ package org.wso2.carbon.identity.x509Certificate.validation;
  */
 public class X509CertificateValidationConstants {
 
-    public static final String VALIDATOR_RESOURCE_TYPE = "Validator";
-    public static final String X509_CA_CERT_FILE = "X509_CA_CERT_FILE";
+    public static final String VALIDATOR_RESOURCE_TYPE = "x509-validators";
+    public static final String X509_CA_CERT_FILE = "x509_ca_cert_file";
     public static final String X509_CERT_PREFIX = "X509_CERT_";
     public static final String X509_CA_CERT_ALIAS = "X509_CA";
     public static final String CERTS = "CERTS";

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/internal/CertValidationDataHolder.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/internal/CertValidationDataHolder.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2018-2025, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.x509Certificate.validation.internal;
 
+import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.registry.core.service.RegistryService;
 import org.wso2.carbon.user.core.service.RealmService;
 
@@ -29,6 +30,7 @@ public class CertValidationDataHolder {
     private static RegistryService registryService;
     private static RealmService realmService;
     private static CertValidationDataHolder instance = new CertValidationDataHolder();
+    private static ConfigurationManager configurationManager;
 
     private CertValidationDataHolder() {
     }
@@ -83,4 +85,23 @@ public class CertValidationDataHolder {
         this.realmService = realmService;
     }
 
+    /**
+     * Set Configuration Manager.
+     *
+     * @param configurationManager configuration manager
+     */
+    public void setConfigurationManager(ConfigurationManager configurationManager) {
+
+        this.configurationManager = configurationManager;
+    }
+
+    /**
+     * Get Configuration Manager.
+     *
+     * @return configuration manager
+     */
+    public ConfigurationManager getConfigurationManager() {
+
+        return configurationManager;
+    }
 }

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/internal/CertValidationDataHolder.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/internal/CertValidationDataHolder.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.x509Certificate.validation.internal;
 
+import org.wso2.carbon.identity.certificate.management.service.CertificateManagementService;
 import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.registry.core.service.RegistryService;
 import org.wso2.carbon.user.core.service.RealmService;
@@ -31,6 +32,7 @@ public class CertValidationDataHolder {
     private static RealmService realmService;
     private static CertValidationDataHolder instance = new CertValidationDataHolder();
     private static ConfigurationManager configurationManager;
+    private static CertificateManagementService certificateManagementService;
 
     private CertValidationDataHolder() {
     }
@@ -103,5 +105,25 @@ public class CertValidationDataHolder {
     public ConfigurationManager getConfigurationManager() {
 
         return configurationManager;
+    }
+
+    /**
+     * Set Certificate Management Service.
+     *
+     * @param service certificate management service
+     */
+    public void setCertificateManagementService(CertificateManagementService service) {
+
+        this.certificateManagementService = service;
+    }
+
+    /**
+     * Get Certificate Management Service.
+     *
+     * @return certificate management service
+     */
+    public CertificateManagementService getCertificateManagementService() {
+
+        return certificateManagementService;
     }
 }

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/internal/X509CertificateValidationServiceComponent.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/internal/X509CertificateValidationServiceComponent.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2018-2025, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -27,6 +27,7 @@ import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
+import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationUtil;
 import org.wso2.carbon.identity.x509Certificate.validation.service.RevocationValidationManager;
 import org.wso2.carbon.identity.x509Certificate.validation.service.RevocationValidationManagerImpl;
@@ -108,4 +109,32 @@ public class X509CertificateValidationServiceComponent {
         CertValidationDataHolder.getInstance().setRealmService(null);
     }
 
+    /**
+     * Set the ConfigurationManager.
+     *
+     * @param configurationManager The {@code ConfigurationManager} instance.
+     */
+    @Reference(
+            name = "resource.configuration.manager",
+            service = ConfigurationManager.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unregisterConfigurationManager"
+    )
+    protected void registerConfigurationManager(ConfigurationManager configurationManager) {
+
+        log.debug("Registering the ConfigurationManager in Certificate Validation Service Component.");
+        CertValidationDataHolder.getInstance().setConfigurationManager(configurationManager);
+    }
+
+    /**
+     * Unset the ConfigurationManager.
+     *
+     * @param configurationManager The {@code ConfigurationManager} instance.
+     */
+    protected void unregisterConfigurationManager(ConfigurationManager configurationManager) {
+
+        log.debug("Unregistering the ConfigurationManager in Certificate Validation Service Component.");
+        CertValidationDataHolder.getInstance().setConfigurationManager(null);
+    }
 }

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/internal/X509CertificateValidationServiceComponent.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/internal/X509CertificateValidationServiceComponent.java
@@ -28,6 +28,7 @@ import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
+import org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent;
 import org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationUtil;
 import org.wso2.carbon.identity.x509Certificate.validation.service.RevocationValidationManager;
 import org.wso2.carbon.identity.x509Certificate.validation.service.RevocationValidationManagerImpl;
@@ -136,5 +137,22 @@ public class X509CertificateValidationServiceComponent {
 
         log.debug("Unregistering the ConfigurationManager in Certificate Validation Service Component.");
         CertValidationDataHolder.getInstance().setConfigurationManager(null);
+    }
+
+    @Reference(
+            name = "identityCoreInitializedEventService",
+            service = IdentityCoreInitializedEvent.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetIdentityCoreInitializedEventService"
+    )
+    protected void setIdentityCoreInitializedEventService(IdentityCoreInitializedEvent identityCoreInitializedEvent) {
+        /* reference IdentityCoreInitializedEvent service to guarantee that this component will wait until identity core
+         is started */
+    }
+
+    protected void unsetIdentityCoreInitializedEventService(IdentityCoreInitializedEvent identityCoreInitializedEvent) {
+        /* reference IdentityCoreInitializedEvent service to guarantee that this component will wait until identity core
+         is started */
     }
 }

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/internal/X509CertificateValidationServiceComponent.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/internal/X509CertificateValidationServiceComponent.java
@@ -27,6 +27,7 @@ import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
+import org.wso2.carbon.identity.certificate.management.service.CertificateManagementService;
 import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent;
 import org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationUtil;
@@ -137,6 +138,35 @@ public class X509CertificateValidationServiceComponent {
 
         log.debug("Unregistering the ConfigurationManager in Certificate Validation Service Component.");
         CertValidationDataHolder.getInstance().setConfigurationManager(null);
+    }
+
+    /**
+     * Set the CertificateManagementService.
+     *
+     * @param certificateManagementService The {@code CertificateManagementService} instance.
+     */
+    @Reference(
+            name = "certificate.mgt.service.component",
+            service = CertificateManagementService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetCertificateManagementService")
+    protected void setCertificateManagementService(CertificateManagementService certificateManagementService) {
+
+        CertValidationDataHolder.getInstance().setCertificateManagementService(certificateManagementService);
+    }
+
+    /**
+     * Unset the CertificateManagementService.
+     *
+     * @param certificateManagementService The {@code CertificateManagementService} instance.
+     */
+    protected void unsetCertificateManagementService(CertificateManagementService certificateManagementService) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Unset certificate Management Service.");
+        }
+        CertValidationDataHolder.getInstance().setCertificateManagementService(null);
     }
 
     @Reference(

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/internal/X509CertificateValidationServiceComponent.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/internal/X509CertificateValidationServiceComponent.java
@@ -153,6 +153,7 @@ public class X509CertificateValidationServiceComponent {
             unbind = "unsetCertificateManagementService")
     protected void setCertificateManagementService(CertificateManagementService certificateManagementService) {
 
+        log.debug("Setting the Certificate Management Service.");
         CertValidationDataHolder.getInstance().setCertificateManagementService(certificateManagementService);
     }
 
@@ -163,9 +164,7 @@ public class X509CertificateValidationServiceComponent {
      */
     protected void unsetCertificateManagementService(CertificateManagementService certificateManagementService) {
 
-        if (log.isDebugEnabled()) {
-            log.debug("Unset certificate Management Service.");
-        }
+        log.debug("Unset certificate Management Service.");
         CertValidationDataHolder.getInstance().setCertificateManagementService(null);
     }
 
@@ -177,11 +176,13 @@ public class X509CertificateValidationServiceComponent {
             unbind = "unsetIdentityCoreInitializedEventService"
     )
     protected void setIdentityCoreInitializedEventService(IdentityCoreInitializedEvent identityCoreInitializedEvent) {
+        log.debug("Identity Core is initialized.");
         /* reference IdentityCoreInitializedEvent service to guarantee that this component will wait until identity core
          is started */
     }
 
     protected void unsetIdentityCoreInitializedEventService(IdentityCoreInitializedEvent identityCoreInitializedEvent) {
+        log.debug("Unset Identity Core initialized event service.");
         /* reference IdentityCoreInitializedEvent service to guarantee that this component will wait until identity core
          is started */
     }

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/model/CertObject.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/model/CertObject.java
@@ -21,7 +21,11 @@ package org.wso2.carbon.identity.x509Certificate.validation.model;
 
 import java.util.List;
 
+/**
+ * Represents a certificate object.
+ */
 public class CertObject {
+
     private List<String> crlUrls;
     private List<String> ocspUrls;
     private String certId;

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/model/CertObject.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/model/CertObject.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.wso2.carbon.identity.x509Certificate.validation.model;
+
+import java.util.List;
+
+public class CertObject {
+    private List<String> crlUrls;
+    private List<String> ocspUrls;
+    private String certId;
+    private String serialNumber;
+
+    // Getters and Setters
+    public List<String> getCrlUrls() {
+        return crlUrls;
+    }
+
+    public void setCrlUrls(List<String> crlUrls) {
+        this.crlUrls = crlUrls;
+    }
+
+    public List<String> getOcspUrls() {
+        return ocspUrls;
+    }
+
+    public void setOcspUrls(List<String> ocspUrls) {
+        this.ocspUrls = ocspUrls;
+    }
+
+    public String getCertId() {
+        return certId;
+    }
+
+    public void setCertId(String certId) {
+        this.certId = certId;
+    }
+
+    public String getSerialNumber() {
+        return serialNumber;
+    }
+
+    public void setSerialNumber(String serialNumber) {
+        this.serialNumber = serialNumber;
+    }
+
+    @Override
+    public String toString() {
+        return "CertObject{" +
+                "crlUrls=" + crlUrls +
+                ", ocspUrls=" + ocspUrls +
+                ", certId='" + certId + '\'' +
+                ", serialNumber='" + serialNumber + '\'' +
+                '}';
+    }
+}

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/model/IssuerDNMap.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/model/IssuerDNMap.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.wso2.carbon.identity.x509Certificate.validation.model;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class IssuerDNMap {
+    private Map<String, List<CertObject>> issuerCertMap = new HashMap<>();
+
+    public Map<String, List<CertObject>> getIssuerCertMap() {
+        return issuerCertMap;
+    }
+
+    public void setIssuerCertMap(Map<String, List<CertObject>> issuerCertMap) {
+        this.issuerCertMap = issuerCertMap;
+    }
+
+    @Override
+    public String toString() {
+        return "IssuerDNMap{" +
+                "issuerCertMap=" + issuerCertMap +
+                '}';
+    }
+}

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/model/IssuerDNMap.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/model/IssuerDNMap.java
@@ -23,7 +23,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Represents a map of issuer DNs to a list of certificates.
+ */
 public class IssuerDNMap {
+
     private Map<String, List<CertObject>> issuerCertMap = new HashMap<>();
 
     public Map<String, List<CertObject>> getIssuerCertMap() {

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/model/ModelSerializer.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/model/ModelSerializer.java
@@ -20,9 +20,11 @@
 package org.wso2.carbon.identity.x509Certificate.validation.model;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+/**
+ * Utility class to serialize and deserialize model objects.
+ */
 public class ModelSerializer {
 
     private static final ObjectMapper objectMapper = new ObjectMapper();

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/model/ModelSerializer.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/model/ModelSerializer.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.wso2.carbon.identity.x509Certificate.validation.model;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class ModelSerializer {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public static String serializeIssuerDNMap(IssuerDNMap issuerDNMap) throws JsonProcessingException {
+        return objectMapper.writeValueAsString(issuerDNMap);
+    }
+
+    public static IssuerDNMap deserializeIssuerDNMap(String json) throws JsonProcessingException {
+        return objectMapper.readValue(json, IssuerDNMap.class);
+    }
+}

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/model/Validator.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/model/Validator.java
@@ -19,7 +19,7 @@
 package org.wso2.carbon.identity.x509Certificate.validation.model;
 
 /**
- * Model representation of a Certificate Validator
+ * Model representation of a Certificate Validator.
  */
 public class Validator {
 

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,11 @@
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.configuration.mgt.core</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
                 <version>${apache.felix.scr.ds.annotations.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,11 @@
                 <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
                 <version>${apache.felix.scr.ds.annotations.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${com.fasterxml.jackson.databind.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>org.wso2.eclipse.osgi</groupId>
@@ -258,6 +263,7 @@
         <imp.pkg.version.javax.servlet>2.4.0</imp.pkg.version.javax.servlet>
         <imp.pkg.version.apache.tomcat>[7.0.0, 9.0.0)</imp.pkg.version.apache.tomcat>
         <slf4j.api.version>1.7.21</slf4j.api.version>
+        <com.fasterxml.jackson.databind.version>2.16.1</com.fasterxml.jackson.databind.version>
 
         <mockito.version>5.3.1</mockito.version>
         <mockito-testng.version>0.5.2</mockito-testng.version>


### PR DESCRIPTION
### Purpose
- Remove registry usage from the components.

This pull request includes several changes to the `components/validation` module, focusing on adding new dependencies, updating copyright information, and introducing new classes for certificate validation.

### Dependency additions and updates:

* [`components/validation/pom.xml`](diffhunk://#diff-891eb748ec8b82059e5b14c4ec092b4a3f482b517191db861fb115ea41139a85L49-R52): Added dependencies for `org.wso2.carbon.identity.configuration.mgt.core` and `com.fasterxml.jackson.core:jackson-databind`. [[1]](diffhunk://#diff-891eb748ec8b82059e5b14c4ec092b4a3f482b517191db861fb115ea41139a85L49-R52) [[2]](diffhunk://#diff-891eb748ec8b82059e5b14c4ec092b4a3f482b517191db861fb115ea41139a85R66-R69) [[3]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R78-R92) [[4]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R266)

### New classes for certificate validation:

* [`components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/model/CertObject.java`](diffhunk://#diff-8f216467241f66310c3b4e0d1118c932191fb8a9686fa87f057b134ab4de4d29R1-R72): Introduced a new class `CertObject` to represent certificate details.
* [`components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/model/IssuerDNMap.java`](diffhunk://#diff-a0afb50de8aeade72c2f29637686948f798ccb75502d18f6811a3452cc2930cbR1-R43): Added a new class `IssuerDNMap` to map issuer DNs to certificate objects.
* [`components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/model/ModelSerializer.java`](diffhunk://#diff-e6f2e315414375a9fb73ec55aadfa8ad4dce262213f96647c844bf6dff8fe817R1-R37): Created a new class `ModelSerializer` for serializing and deserializing `IssuerDNMap` objects using Jackson.

### Updates to existing classes:

* [`components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/X509CertificateValidationConstants.java`](diffhunk://#diff-330df172d9f0491fc2c1e931a0056abe0b57b4f2c62821453680313ccf0157bdR26-R30): Added new constants related to certificate validation.
* [`components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/internal/CertValidationDataHolder.java`](diffhunk://#diff-b72f0d3e8793d4af287ed59aa606c2c00898bf8be440a747160335eb5ab6dd89R21-R22): Added fields and methods for `ConfigurationManager` and `CertificateManagementService`. [[1]](diffhunk://#diff-b72f0d3e8793d4af287ed59aa606c2c00898bf8be440a747160335eb5ab6dd89R21-R22) [[2]](diffhunk://#diff-b72f0d3e8793d4af287ed59aa606c2c00898bf8be440a747160335eb5ab6dd89R34-R35) [[3]](diffhunk://#diff-b72f0d3e8793d4af287ed59aa606c2c00898bf8be440a747160335eb5ab6dd89R90-R128)
* [`components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/internal/X509CertificateValidationServiceComponent.java`](diffhunk://#diff-7ef2ca95652ce91bd9610d39fe04378a1c3d60733e9d055d7178f6c7b1a974f3R30-R32): Added methods to register and unregister `ConfigurationManager` and `CertificateManagementService`. [[1]](diffhunk://#diff-7ef2ca95652ce91bd9610d39fe04378a1c3d60733e9d055d7178f6c7b1a974f3R30-R32) [[2]](diffhunk://#diff-7ef2ca95652ce91bd9610d39fe04378a1c3d60733e9d055d7178f6c7b1a974f3R114-R187)