### PR TITLE
Added conditional logic to check the x509 authenticator enabling

### DIFF
--- a/features/validation/org.wso2.carbon.extension.identity.x509Certificate.validation.server.feature/resources/certificate-validation.xml.j2
+++ b/features/validation/org.wso2.carbon.extension.identity.x509Certificate.validation.server.feature/resources/certificate-validation.xml.j2
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <CertificateValidation xmlns="http://wso2.org/projects/carbon/certificate-validation.xml">
+{% if authentication.authenticator.x509_certificate.parameters.enable %}
 <Validators>
 	<!-- Validator for validating revocation status of X509 cerificate with CRL -->
 	<Validator name="org.wso2.carbon.identity.x509Certificate.validation.validator.OCSPValidator"
@@ -27,5 +28,6 @@
 <TrustStores>
   <TrustStore truststoreFile="{{certificate_validation.truststore.file_path}}" truststorePass="{{certificate_validation.truststore.password}}" type="{{certificate_validation.truststore.type}}"/>
 </TrustStores>
+{% endif %}
 {% endif %}
 </CertificateValidation>


### PR DESCRIPTION
This pull request includes changes to the `certificate-validation.xml.j2` file to add conditional logic for enabling certificate validation based on a configuration parameter.

Enhancements to certificate validation configuration:

* [`features/validation/org.wso2.carbon.extension.identity.x509Certificate.validation.server.feature/resources/certificate-validation.xml.j2`](diffhunk://#diff-c11e8d91c2537f488a6988bd1287a4d16fe705983f6325a961744515919c5627R3): Added conditional logic to wrap the entire `<Validators>` section and `<TrustStores>` section with a check for `authentication.authenticator.x509_certificate.parameters.enable`. [[1]](diffhunk://#diff-c11e8d91c2537f488a6988bd1287a4d16fe705983f6325a961744515919c5627R3) [[2]](diffhunk://#diff-c11e8d91c2537f488a6988bd1287a4d16fe705983f6325a961744515919c5627R32)

### Related Issues
- https://github.com/wso2/product-is/issues/22408