### PR TITLE
configure the maven-javadoc-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,6 +220,26 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>buildnumber-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <!--This parameter disables doclint-->
+                            <doclint>none</doclint>
+                            <quiet>true</quiet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
This pull request includes an important addition to the `pom.xml` file to enhance the Maven build process by generating Javadocs.

Enhancements to Maven build process:

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R223-R242): Added the `maven-javadoc-plugin` to generate Javadocs with a configuration that disables doclint and sets the source to 1.8. The plugin is configured to attach the Javadocs as a jar during the build process.