### PR TITLE
Set source version as 1.8 in javadoc plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,6 +220,13 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>buildnumber-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
## Purpose
$subject.

Fixing the error:
`Exit code: 1 - javadoc: error - The code being documented uses modules but the packages defined in https://docs.oracle.com/javase/8/docs/api/ are in the unnamed module.` in the release build.