### PR TITLE
Add capability store x509 validation CAs in certificate management

### DIFF
--- a/components/validation/pom.xml
+++ b/components/validation/pom.xml
@@ -63,6 +63,10 @@
             <groupId>org.wso2.orbit.org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/ModelSerializer.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/ModelSerializer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.wso2.carbon.identity.x509Certificate.validation;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.wso2.carbon.identity.x509Certificate.validation.model.IssuerDNMap;
+
+/**
+ * Utility class to serialize and deserialize model objects.
+ */
+public class ModelSerializer {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public static String serializeIssuerDNMap(IssuerDNMap issuerDNMap) throws JsonProcessingException {
+
+        return objectMapper.writeValueAsString(issuerDNMap);
+    }
+
+    public static IssuerDNMap deserializeIssuerDNMap(String json) throws JsonProcessingException {
+
+        return objectMapper.readValue(json, IssuerDNMap.class);
+    }
+}

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/X509CertificateValidationConstants.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/X509CertificateValidationConstants.java
@@ -24,6 +24,10 @@ package org.wso2.carbon.identity.x509Certificate.validation;
 public class X509CertificateValidationConstants {
 
     public static final String VALIDATOR_RESOURCE_TYPE = "X509_VALIDATOR";
+    public static final String X509_CA_CERT_FILE = "x509_ca_cert_file";
+    public static final String X509_CERT_PREFIX = "X509_CERT_";
+    public static final String X509_CA_CERT_RESOURCE_TYPE = "X509_REVOCATION_VALIDATION_CA";
+    public static final String CERTS = "CERTS";
     public static final String CERT_VALIDATION_CONF_DIRECTORY = "security";
     public static final String CERT_VALIDATION_CONF_FILE = "certificate-validation.xml";
     public static final String VALIDATOR_CONF = "Validators";

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/internal/CertValidationDataHolder.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/internal/CertValidationDataHolder.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.x509Certificate.validation.internal;
 
+import org.wso2.carbon.identity.certificate.management.service.CertificateManagementService;
 import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.registry.core.service.RegistryService;
 import org.wso2.carbon.user.core.service.RealmService;
@@ -31,6 +32,7 @@ public class CertValidationDataHolder {
     private static RealmService realmService;
     private static CertValidationDataHolder instance = new CertValidationDataHolder();
     private static ConfigurationManager configurationManager;
+    private static CertificateManagementService certificateManagementService;
 
     private CertValidationDataHolder() {
     }
@@ -103,5 +105,25 @@ public class CertValidationDataHolder {
     public ConfigurationManager getConfigurationManager() {
 
         return configurationManager;
+    }
+
+    /**
+     * Set Certificate Management Service.
+     *
+     * @param service certificate management service
+     */
+    public void setCertificateManagementService(CertificateManagementService service) {
+
+        this.certificateManagementService = service;
+    }
+
+    /**
+     * Get Certificate Management Service.
+     *
+     * @return certificate management service
+     */
+    public CertificateManagementService getCertificateManagementService() {
+
+        return certificateManagementService;
     }
 }

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/internal/X509CertificateValidationServiceComponent.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/internal/X509CertificateValidationServiceComponent.java
@@ -27,6 +27,7 @@ import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
+import org.wso2.carbon.identity.certificate.management.service.CertificateManagementService;
 import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent;
 import org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationUtil;
@@ -137,6 +138,34 @@ public class X509CertificateValidationServiceComponent {
 
         log.debug("Unregistering the ConfigurationManager in Certificate Validation Service Component.");
         CertValidationDataHolder.getInstance().setConfigurationManager(null);
+    }
+
+    /**
+     * Set the CertificateManagementService.
+     *
+     * @param certificateManagementService The {@code CertificateManagementService} instance.
+     */
+    @Reference(
+            name = "certificate.mgt.service.component",
+            service = CertificateManagementService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetCertificateManagementService")
+    protected void setCertificateManagementService(CertificateManagementService certificateManagementService) {
+
+        log.debug("Setting the Certificate Management Service.");
+        CertValidationDataHolder.getInstance().setCertificateManagementService(certificateManagementService);
+    }
+
+    /**
+     * Unset the CertificateManagementService.
+     *
+     * @param certificateManagementService The {@code CertificateManagementService} instance.
+     */
+    protected void unsetCertificateManagementService(CertificateManagementService certificateManagementService) {
+
+        log.debug("Unset certificate Management Service.");
+        CertValidationDataHolder.getInstance().setCertificateManagementService(null);
     }
 
     @Reference(

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/model/CACertificate.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/model/CACertificate.java
@@ -22,7 +22,7 @@ import java.security.cert.X509Certificate;
 import java.util.List;
 
 /**
- * Model representation of a CA certificate
+ * Model representation of a CA certificate.
  */
 public class CACertificate {
 

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/model/CertObject.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/model/CertObject.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.wso2.carbon.identity.x509Certificate.validation.model;
+
+import java.util.List;
+
+/**
+ * Represents a certificate object.
+ */
+public class CertObject {
+
+    private List<String> crlUrls;
+    private List<String> ocspUrls;
+    private String certId;
+    private String serialNumber;
+
+    public List<String> getCrlUrls() {
+
+        return crlUrls;
+    }
+
+    public void setCrlUrls(List<String> crlUrls) {
+
+        this.crlUrls = crlUrls;
+    }
+
+    public List<String> getOcspUrls() {
+
+        return ocspUrls;
+    }
+
+    public void setOcspUrls(List<String> ocspUrls) {
+
+        this.ocspUrls = ocspUrls;
+    }
+
+    public String getCertId() {
+
+        return certId;
+    }
+
+    public void setCertId(String certId) {
+
+        this.certId = certId;
+    }
+
+    public String getSerialNumber() {
+
+        return serialNumber;
+    }
+
+    public void setSerialNumber(String serialNumber) {
+
+        this.serialNumber = serialNumber;
+    }
+
+    @Override
+    public String toString() {
+
+        return "CertObject{" +
+                "crlUrls=" + crlUrls +
+                ", ocspUrls=" + ocspUrls +
+                ", certId='" + certId + '\'' +
+                ", serialNumber='" + serialNumber + '\'' +
+                '}';
+    }
+}

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/model/IssuerDNMap.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/model/IssuerDNMap.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.wso2.carbon.identity.x509Certificate.validation.model;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Represents a map of issuer DNs to a list of certificates.
+ */
+public class IssuerDNMap {
+
+    private Map<String, List<CertObject>> issuerCertMap = new HashMap<>();
+
+    public Map<String, List<CertObject>> getIssuerCertMap() {
+
+        return issuerCertMap;
+    }
+
+    public void setIssuerCertMap(Map<String, List<CertObject>> issuerCertMap) {
+
+        this.issuerCertMap = issuerCertMap;
+    }
+
+    @Override
+    public String toString() {
+
+        return "IssuerDNMap{" +
+                "issuerCertMap=" + issuerCertMap +
+                '}';
+    }
+}

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/model/Validator.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/model/Validator.java
@@ -19,7 +19,7 @@
 package org.wso2.carbon.identity.x509Certificate.validation.model;
 
 /**
- * Model representation of a Certificate Validator
+ * Model representation of a Certificate Validator.
  */
 public class Validator {
 

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,11 @@
                 <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
                 <version>${apache.felix.scr.ds.annotations.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${com.fasterxml.jackson.databind.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>org.wso2.eclipse.osgi</groupId>
@@ -265,6 +270,7 @@
         <imp.pkg.version.javax.servlet>2.4.0</imp.pkg.version.javax.servlet>
         <imp.pkg.version.apache.tomcat>[7.0.0, 9.0.0)</imp.pkg.version.apache.tomcat>
         <slf4j.api.version>1.7.21</slf4j.api.version>
+        <com.fasterxml.jackson.databind.version>2.16.1</com.fasterxml.jackson.databind.version>
 
         <mockito.version>5.3.1</mockito.version>
         <mockito-testng.version>0.5.2</mockito-testng.version>


### PR DESCRIPTION
## Purpose
$subject.. Originally contributed in,
* https://github.com/wso2-extensions/identity-x509-commons/pull/47


Related to,
* https://github.com/wso2/product-is/issues/22408