### PR TITLE
Introduce Persisting Manager to Certificate Validation Service

### DIFF
--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/CertificateValidationUtil.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/CertificateValidationUtil.java
@@ -126,6 +126,7 @@ import org.wso2.carbon.identity.x509Certificate.validation.persistence.Certifica
 import org.wso2.carbon.identity.x509Certificate.validation.persistence.CertificateValidationPersistenceManagerFactory;
 import org.wso2.carbon.identity.x509Certificate.validation.validator.RevocationValidator;
 import org.wso2.carbon.registry.core.Resource;
+import org.wso2.carbon.registry.core.ResourceImpl;
 import org.wso2.carbon.utils.CarbonUtils;
 import org.wso2.carbon.utils.ServerConstants;
 import org.wso2.carbon.utils.security.KeystoreUtils;
@@ -177,8 +178,7 @@ public class CertificateValidationUtil {
                     addDefaultCACertificates(trustStoresElement, validatorChildElement, tenantDomain);
                 }
 
-            } catch (XMLStreamException | FileNotFoundException | CertificateValidationException |
-                     CertificateValidationManagementException e) {
+            } catch (XMLStreamException | FileNotFoundException | CertificateValidationManagementException e) {
                 log.warn("Error while loading default validator configurations.", e);
             } finally {
                 try {
@@ -318,7 +318,7 @@ public class CertificateValidationUtil {
     public static Validator resourceToValidatorObject(Resource resource) {
 
         Validator validator = new Validator();
-        validator.setName(resource.getProperty(VALIDATOR_CONF_NAME));
+        validator.setDisplayName(((ResourceImpl)resource).getName());
         validator.setEnabled(Boolean.parseBoolean(resource.getProperty(VALIDATOR_CONF_ENABLE)));
         validator.setPriority(Integer.parseInt(resource.getProperty(VALIDATOR_CONF_PRIORITY)));
         validator.setFullChainValidationEnabled(

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/CertificateValidationUtil.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/CertificateValidationUtil.java
@@ -1630,7 +1630,7 @@ public class CertificateValidationUtil {
      *
      * @param caCertificate X509Certificate
      * @param certObject    CertObject
-     *                      return CACertificateInfo
+     * return CACertificateInfo
      */
     public static CACertificateInfo getCACertificateInfo(X509Certificate caCertificate, CertObject certObject) {
 

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/CertificateValidationUtil.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/CertificateValidationUtil.java
@@ -18,20 +18,13 @@
 
 package org.wso2.carbon.identity.x509Certificate.validation;
 
-import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_RESOURCE_ALREADY_EXISTS;
-import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.CA_CERT_REG_CRL;
-import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.CA_CERT_REG_CRL_OCSP_SEPERATOR;
-import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.CA_CERT_REG_OCSP;
 import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.CA_CERT_REG_PATH;
-import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.CERTS;
 import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.CERT_VALIDATION_CONF_DIRECTORY;
 import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.CERT_VALIDATION_CONF_FILE;
-import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.CRL_VALIDATOR;
 import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.HTTP_ACCEPT;
 import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.HTTP_ACCEPT_OCSP;
 import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.HTTP_CONTENT_TYPE;
 import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.HTTP_CONTENT_TYPE_OCSP;
-import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.OCSP_VALIDATOR;
 import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.TRUSTSTORE_CONF;
 import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.TRUSTSTORE_CONF_FILE;
 import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.TRUSTSTORE_CONF_PASSWORD;
@@ -43,22 +36,14 @@ import static org.wso2.carbon.identity.x509Certificate.validation.X509Certificat
 import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.VALIDATOR_CONF_FULL_CHAIN_VALIDATION;
 import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.VALIDATOR_CONF_NAME;
 import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.VALIDATOR_CONF_PRIORITY;
-import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.VALIDATOR_CONF_REG_PATH;
 import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.VALIDATOR_CONF_RETRY_COUNT;
-import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.VALIDATOR_RESOURCE_TYPE;
-import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.X509_CA_CERT_FILE;
-import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.X509_CA_CERT_RESOURCE_TYPE;
-import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.X509_CERT_PREFIX;
 import static org.wso2.carbon.registry.core.RegistryConstants.PATH_SEPARATOR;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -71,6 +56,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
+import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.Provider;
@@ -83,15 +69,12 @@ import java.security.cert.CertificateFactory;
 import java.security.cert.X509CRL;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamException;
 import org.apache.axiom.om.OMElement;
@@ -133,29 +116,16 @@ import org.bouncycastle.operator.DigestCalculatorProvider;
 import org.bouncycastle.operator.jcajce.JcaDigestCalculatorProviderBuilder;
 import org.wso2.carbon.base.ServerConfiguration;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
-import org.wso2.carbon.identity.certificate.management.constant.CertificateMgtErrors;
-import org.wso2.carbon.identity.certificate.management.exception.CertificateMgtException;
-import org.wso2.carbon.identity.certificate.management.model.Certificate;
-import org.wso2.carbon.identity.configuration.mgt.core.exception.ConfigurationManagementException;
-import org.wso2.carbon.identity.configuration.mgt.core.model.Attribute;
-import org.wso2.carbon.identity.configuration.mgt.core.model.ResourceFile;
-import org.wso2.carbon.identity.configuration.mgt.core.model.Resources;
 import org.wso2.carbon.identity.core.util.IdentityConfigParser;
-import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.x509Certificate.validation.cache.CRLCache;
 import org.wso2.carbon.identity.x509Certificate.validation.cache.CRLCacheEntry;
-import org.wso2.carbon.identity.x509Certificate.validation.internal.CertValidationDataHolder;
+import org.wso2.carbon.identity.x509Certificate.validation.exception.CertificateValidationManagementException;
 import org.wso2.carbon.identity.x509Certificate.validation.model.CACertificate;
-import org.wso2.carbon.identity.x509Certificate.validation.model.CACertificateInfo;
-import org.wso2.carbon.identity.x509Certificate.validation.model.CertObject;
-import org.wso2.carbon.identity.x509Certificate.validation.model.IssuerDNMap;
 import org.wso2.carbon.identity.x509Certificate.validation.model.Validator;
+import org.wso2.carbon.identity.x509Certificate.validation.persistence.CertificateValidationPersistenceManager;
+import org.wso2.carbon.identity.x509Certificate.validation.persistence.CertificateValidationPersistenceManagerFactory;
 import org.wso2.carbon.identity.x509Certificate.validation.validator.RevocationValidator;
-import org.wso2.carbon.registry.core.Collection;
-import org.wso2.carbon.registry.core.Registry;
 import org.wso2.carbon.registry.core.Resource;
-import org.wso2.carbon.registry.core.exceptions.RegistryException;
-import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.utils.CarbonUtils;
 import org.wso2.carbon.utils.ServerConstants;
 import org.wso2.carbon.utils.security.KeystoreUtils;
@@ -168,6 +138,8 @@ public class CertificateValidationUtil {
     private static final String CRL_CACHE_SYNC_LOCK_PREFIX = "CRLCacheLock:";
     private static final String CRL_DOWNLOAD_TIMEOUT_CONFIG = "X509.CRLDownloadTimeout";
     private static final Log log = LogFactory.getLog(CertificateValidationUtil.class);
+    private static final CertificateValidationPersistenceManager certificateValidationPersistenceManager =
+            CertificateValidationPersistenceManagerFactory.getX509CertificatePersistenceManager();
     private static int CRL_DOWNLOAD_TIMEOUT = 60000;
 
     /**
@@ -205,7 +177,8 @@ public class CertificateValidationUtil {
                     addDefaultCACertificates(trustStoresElement, validatorChildElement, tenantDomain);
                 }
 
-            } catch (XMLStreamException | FileNotFoundException | CertificateValidationException e) {
+            } catch (XMLStreamException | FileNotFoundException | CertificateValidationException |
+                     CertificateValidationManagementException e) {
                 log.warn("Error while loading default validator configurations.", e);
             } finally {
                 try {
@@ -249,38 +222,11 @@ public class CertificateValidationUtil {
             throws CertificateValidationException {
 
         try {
-            return getRevocationValidators(getValidatorsFromConfigStore(PrivilegedCarbonContext
+            return getRevocationValidators(certificateValidationPersistenceManager.getValidators(PrivilegedCarbonContext
                     .getThreadLocalCarbonContext().getTenantDomain()));
-        } catch (ConfigurationManagementException e) {
+        } catch (CertificateValidationManagementException e) {
             throw new CertificateValidationException("Error while fetching validator configurations.", e);
         }
-    }
-
-    private static List<RevocationValidator> getRevocationValidatorsFromRegistry()
-            throws CertificateValidationException {
-
-        String validatorConfRegPath = VALIDATOR_CONF_REG_PATH;
-        List<RevocationValidator> validators = null;
-
-        try {
-            if (log.isDebugEnabled()) {
-                log.debug("Loading X509 certificate validator configurations from registry in: " +
-                        validatorConfRegPath);
-            }
-            //get tenant registry for loading validator configurations
-            Registry registry = getGovernanceRegistry(
-                    PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain());
-            if (registry.resourceExists(validatorConfRegPath)) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Validator configurations are available in registry path: " + validatorConfRegPath);
-                }
-                validators = getEnabledValidatorsFromRegistryResource(registry, validatorConfRegPath);
-            }
-        } catch (RegistryException e) {
-            throw new CertificateValidationException("Error while loading validator configurations from registry in: " +
-                    validatorConfRegPath, e);
-        }
-        return validators;
     }
 
     private static File getValidatorConfigFile() {
@@ -306,33 +252,6 @@ public class CertificateValidationUtil {
         return childElement.getLocalName().equals(VALIDATOR_CONF);
     }
 
-    private static void addDefaultValidatorConfig(OMElement validatorsElement, String tenantDomain) {
-
-        List<Validator> defaultValidatorConfig = getDefaultValidatorConfig(validatorsElement);
-
-        // iterate through the validator config list and write to the registry
-        for (Validator validator : defaultValidatorConfig) {
-            String validatorConfRegPath =
-                    VALIDATOR_CONF_REG_PATH + PATH_SEPARATOR + getNormalizedName(validator.getDisplayName());
-            if (log.isDebugEnabled()) {
-                log.debug("Adding default validator configurations to registry in: " +
-                        validatorConfRegPath);
-            }
-            try {
-                Registry registry = getGovernanceRegistry(tenantDomain);
-                if (!registry.resourceExists(validatorConfRegPath)) {
-                    addValidatorConfigInRegistry(registry, validatorConfRegPath, validator);
-                    if (log.isDebugEnabled()) {
-                        log.debug(String.format("Validator configuration for %s is added to %s tenant registry.",
-                                validator.getDisplayName(), tenantDomain));
-                    }
-                }
-            } catch (RegistryException | CertificateValidationException e) {
-                log.error("Error while adding validator configurations in registry.", e);
-            }
-        }
-    }
-
     private static List<Validator> getDefaultValidatorConfig(OMElement validatorsElement) {
 
         List<Validator> defaultValidatorConfig = new ArrayList<>();
@@ -356,19 +275,6 @@ public class CertificateValidationUtil {
         return defaultValidatorConfig;
     }
 
-    private static void addValidatorConfigInRegistry(Registry registry, String validatorConfRegPath,
-                                                     Validator validator) throws RegistryException {
-
-        Resource resource = registry.newResource();
-        resource.addProperty(VALIDATOR_CONF_NAME, validator.getName());
-        resource.addProperty(VALIDATOR_CONF_ENABLE, Boolean.toString(validator.isEnabled()));
-        resource.addProperty(VALIDATOR_CONF_PRIORITY, Integer.toString(validator.getPriority()));
-        resource.addProperty(VALIDATOR_CONF_FULL_CHAIN_VALIDATION,
-                Boolean.toString(validator.isFullChainValidationEnabled()));
-        resource.addProperty(VALIDATOR_CONF_RETRY_COUNT, Integer.toString(validator.getRetryCount()));
-        registry.put(validatorConfRegPath, resource);
-    }
-
     private static Map<String, String> getValidatorProperties(OMElement validatorElement) {
 
         Map<String, String> validatorProperties = new HashMap<>();
@@ -383,23 +289,6 @@ public class CertificateValidationUtil {
             }
         }
         return validatorProperties;
-    }
-
-    private static List<RevocationValidator> getEnabledValidatorsFromRegistryResource(Registry registry,
-                                                                                      String validatorConfRegPath)
-            throws RegistryException {
-
-        List<Validator> validators = new ArrayList<>();
-        Collection collection = (Collection) registry.get(validatorConfRegPath);
-        if (collection != null) {
-            String[] children = collection.getChildren();
-            for (String child : children) {
-                Resource resource = registry.get(child);
-                validators.add(resourceToValidatorObject(resource));
-            }
-        }
-
-        return getRevocationValidators(validators);
     }
 
     private static List<RevocationValidator> getRevocationValidators(List<Validator> validators) {
@@ -426,7 +315,7 @@ public class CertificateValidationUtil {
         return revocationValidators;
     }
 
-    private static Validator resourceToValidatorObject(Resource resource) {
+    public static Validator resourceToValidatorObject(Resource resource) {
 
         Validator validator = new Validator();
         validator.setName(resource.getProperty(VALIDATOR_CONF_NAME));
@@ -459,11 +348,13 @@ public class CertificateValidationUtil {
         try {
             caRegPath = getCACertsRegPath(peerCertificate);
             if (log.isDebugEnabled()) {
-                log.debug("CA certificate registry full path: " + caRegPath);
+                log.debug("CA certificate full path: " + caRegPath);
             }
-            caCertificateList = getCACertsFromConfigStore(getNormalizedName(peerCertificate.getIssuerDN().getName()));
-        } catch (UnsupportedEncodingException | ConfigurationManagementException e) {
-            throw new CertificateValidationException("Error while loading CA certificates from registry in:" +
+            caCertificateList = certificateValidationPersistenceManager.getCACertsByIssuer(
+                    getNormalizedName(peerCertificate.getIssuerDN().getName()), PrivilegedCarbonContext
+                            .getThreadLocalCarbonContext().getTenantDomain());
+        } catch (UnsupportedEncodingException | CertificateValidationManagementException e) {
+            throw new CertificateValidationException("Error while loading CA certificates in:" +
                     caRegPath, e);
         }
         return caCertificateList;
@@ -480,14 +371,14 @@ public class CertificateValidationUtil {
                 getAllTrustedCerts(trustStoreIterator, trustedCertificates);
             }
 
-            addDefaultCACertificateInRegistry(validatorChildElement, trustedCertificates, tenantDomain);
-        } catch (CertificateMgtException | CertificateException | JsonProcessingException |
-                 CertificateValidationException e) {
+            certificateValidationPersistenceManager.addCACertificates(getDefaultValidatorConfig(validatorChildElement),
+                    trustedCertificates, tenantDomain);
+        } catch (CertificateValidationManagementException e) {
             log.error("Error while adding validator configurations in config store.", e);
         }
     }
 
-    private static String getCACertRegFullPath(X509Certificate certificate) throws UnsupportedEncodingException {
+    public static String getCACertRegFullPath(X509Certificate certificate) throws UnsupportedEncodingException {
 
         return CA_CERT_REG_PATH + PATH_SEPARATOR +
                 URLEncoder.encode(getNormalizedName(certificate.getSubjectDN().getName()), "UTF-8")
@@ -500,210 +391,6 @@ public class CertificateValidationUtil {
         return CA_CERT_REG_PATH + PATH_SEPARATOR +
                 URLEncoder.encode(getNormalizedName(peerCertificate.getIssuerDN().getName()), "UTF-8")
                         .replaceAll("%", ":");
-    }
-
-    private static List<CACertificate> getCACertsFromRegResource(String caRegPath) throws RegistryException,
-            CertificateValidationException {
-
-        List<CACertificate> caCertificateList = new ArrayList<>();
-        //get tenant registry for loading validator configurations
-        Registry registry = getGovernanceRegistry(
-                PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain());
-
-        if (registry.resourceExists(caRegPath)) {
-            Collection collection = (Collection) registry.get(caRegPath);
-            if (collection != null) {
-                String[] children = collection.getChildren();
-                for (String child : children) {
-                    Resource resource = registry.get(child);
-                    CACertificate caCertificate = resourceToCACertObject(resource);
-                    caCertificateList.add(caCertificate);
-                }
-            }
-        }
-        return caCertificateList;
-    }
-
-    private static CACertificate resourceToCACertObject(Resource resource) throws CertificateValidationException {
-
-        List<String> crlUrls;
-        List<String> ocspUrls;
-        X509Certificate x509Certificate;
-        try {
-            String crlUrlReg = resource.getProperty(CA_CERT_REG_CRL);
-            String ocspUrlReg = resource.getProperty(CA_CERT_REG_OCSP);
-            crlUrls = Arrays.asList(crlUrlReg.split(CA_CERT_REG_CRL_OCSP_SEPERATOR));
-            ocspUrls = Arrays.asList(ocspUrlReg.split(CA_CERT_REG_CRL_OCSP_SEPERATOR));
-            byte[] regContent = (byte[]) resource.getContent();
-            x509Certificate = decodeCertificate(new String(regContent));
-        } catch (RegistryException | CertificateException e) {
-            throw new CertificateValidationException("Error when converting registry resource content.", e);
-        }
-        return new CACertificate(crlUrls, ocspUrls, x509Certificate);
-    }
-
-    private static List<CACertificate> getCACertsFromConfigStore(String issuerDN) throws
-            ConfigurationManagementException, CertificateValidationException {
-
-        org.wso2.carbon.identity.configuration.mgt.core.model.Resource resource = CertValidationDataHolder.getInstance()
-                .getConfigurationManager()
-                .getResource(X509_CA_CERT_RESOURCE_TYPE, CERTS);
-
-        return getCertificateListFromResourceAndIssuerDN(resource, issuerDN);
-    }
-
-    private static List<CACertificate> getCertificateListFromResourceAndIssuerDN(
-            org.wso2.carbon.identity.configuration.mgt.core.model.Resource resource, String issuerDN)
-            throws CertificateValidationException {
-
-        List<CACertificate> certificateList = new ArrayList<>();
-
-        try {
-            List<ResourceFile> resourceFiles = resource.getFiles();
-            if (resourceFiles == null || resourceFiles.isEmpty()) {
-                log.warn("Resource files are empty for certificates in tenant: " + resource.getTenantDomain());
-                return certificateList;
-            }
-
-            ResourceFile resourceFile = resourceFiles.get(0);
-            if (resourceFile == null) {
-                log.warn("Resource file is null for certificates in tenant: " + resource.getTenantDomain());
-                return certificateList;
-            }
-
-            InputStream inputStream = CertValidationDataHolder.getInstance()
-                    .getConfigurationManager()
-                    .getFileById(X509_CA_CERT_RESOURCE_TYPE, CERTS, resourceFile.getId());
-
-            if (inputStream == null) {
-                log.warn("InputStream is null for the file in resource for IssuerDN: " + issuerDN);
-                return certificateList;
-            }
-
-            String fileContent = convertInputStreamToString(inputStream);
-            IssuerDNMap issuerDNMap = ModelSerializer.deserializeIssuerDNMap(fileContent);
-
-            List<CertObject> certObjects = issuerDNMap.getIssuerCertMap().get(issuerDN);
-            if (certObjects != null) {
-                for (CertObject certObject : certObjects) {
-                    // Extract details from the CertObject
-                    String certId = certObject.getCertId();
-                    List<String> crlUrls = certObject.getCrlUrls();
-                    List<String> ocspUrls = certObject.getOcspUrls();
-
-                    Certificate certificate = CertValidationDataHolder.getInstance()
-                            .getCertificateManagementService()
-                            .getCertificate(certId, PrivilegedCarbonContext.getThreadLocalCarbonContext()
-                                    .getTenantDomain());
-
-                    X509Certificate x509Certificate = decodeCertificate(certificate.getCertificateContent());
-
-                    CACertificate caCertificate = new CACertificate(crlUrls, ocspUrls, x509Certificate);
-                    certificateList.add(caCertificate);
-                }
-            }
-        } catch (IOException e) {
-            log.error("Error while reading the file content for IssuerDN: " + issuerDN, e);
-            throw new CertificateValidationException("Error while reading the file content for IssuerDN: " +
-                    issuerDN, e);
-        } catch (Exception e) {
-            log.error("Error while processing the resource for IssuerDN: " + issuerDN, e);
-            throw new CertificateValidationException("Error while processing the resource for IssuerDN: " +
-                    issuerDN, e);
-        }
-
-        return certificateList;
-    }
-
-    private static String convertInputStreamToString(InputStream inputStream) throws IOException {
-        StringBuilder stringBuilder = new StringBuilder();
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
-            String line;
-            while ((line = reader.readLine()) != null) {
-                stringBuilder.append(line);
-            }
-        }
-        return stringBuilder.toString();
-    }
-
-    private static void addDefaultCACertificateInRegistry(OMElement validatorChildElement,
-                                                          List<X509Certificate> trustedCertificates,
-                                                          String tenantDomain) throws
-            CertificateValidationException, CertificateException, CertificateMgtException, JsonProcessingException {
-
-        Map<String, List<CertObject>> issuerDNMap = new HashMap<>();
-        for (X509Certificate certificate : trustedCertificates) {
-            String issuerDN = getNormalizedName(certificate.getIssuerDN().getName());
-            String serialNumber = getNormalizedName(certificate.getSerialNumber().toString());
-
-            // Check if the serial number already exists for the given IssuerDN
-            List<CertObject> existingCertObjects = issuerDNMap.computeIfAbsent(issuerDN, k -> new ArrayList<>());
-            boolean isSerialNumberAlreadyAdded = existingCertObjects.stream()
-                    .anyMatch(certObject -> certObject.getSerialNumber().equals(serialNumber));
-
-            if (isSerialNumberAlreadyAdded) {
-                log.warn("Certificate with serial number " + serialNumber + " already exists for IssuerDN " +
-                        issuerDN);
-                continue;
-            }
-
-            List<String> ocspUrls = new ArrayList<>();
-            List<String> crlUrls = new ArrayList<>();
-            boolean isSelfSignedCert = isSelfSignedCert(certificate);
-
-            // Process default validators for this certificate
-            List<Validator> defaultValidatorConfig = getDefaultValidatorConfig(validatorChildElement);
-            for (Validator validator : defaultValidatorConfig) {
-                if (validator.isEnabled()) {
-                    if (OCSP_VALIDATOR.equals(validator.getDisplayName()) &&
-                            !isSelfSignedCert) {
-                        ocspUrls = getAIALocations(certificate);
-                    } else if (CRL_VALIDATOR.equals(validator.getDisplayName()) &&
-                            !isSelfSignedCert) {
-                        crlUrls = getCRLUrls(certificate);
-                    }
-                }
-            }
-
-            Certificate cert = new Certificate.Builder()
-                    .name(X509_CERT_PREFIX + UUID.randomUUID())
-                    .certificateContent(encodeCertificate(certificate))
-                    .build();
-            String certId = CertValidationDataHolder.getInstance().getCertificateManagementService()
-                    .addCertificate(cert, tenantDomain);
-
-            CertObject certObject = new CertObject();
-            certObject.setCertId(certId); // Assuming serialNumber as certId for simplicity
-            certObject.setSerialNumber(serialNumber);
-            certObject.setCrlUrls(crlUrls);
-            certObject.setOcspUrls(ocspUrls);
-
-            existingCertObjects.add(certObject);
-        }
-
-        IssuerDNMap combinedIssuerDNMap = new IssuerDNMap();
-        for (Map.Entry<String, List<CertObject>> entry : issuerDNMap.entrySet()) {
-            String issuerDN = entry.getKey();
-            List<CertObject> certObjects = entry.getValue();
-            combinedIssuerDNMap.getIssuerCertMap().put(issuerDN, certObjects);
-        }
-
-        String serializedContent = ModelSerializer.serializeIssuerDNMap(combinedIssuerDNMap);
-
-        InputStream inputStream = new ByteArrayInputStream(serializedContent.getBytes(StandardCharsets.UTF_8));
-
-        ResourceFile resourceFile = new ResourceFile();
-        resourceFile.setName(X509_CA_CERT_FILE);
-        resourceFile.setInputStream(inputStream);
-
-        org.wso2.carbon.identity.configuration.mgt.core.model.Resource resource =
-                new org.wso2.carbon.identity.configuration.mgt.core.model.Resource(CERTS, X509_CA_CERT_RESOURCE_TYPE);
-        resource.setHasFile(true);
-        resource.setFiles(new ArrayList<>());
-        resource.getFiles().add(resourceFile);
-
-        // Add the resource to the configuration store
-        addResource(resource);
     }
 
     private static void getAllTrustedCerts(Iterator trustStoreIterator, List<X509Certificate> trustedCertificates) {
@@ -1270,7 +957,7 @@ public class CertificateValidationUtil {
      * @return encoded certificate
      * @throws CertificateException certificateException
      */
-    private static String encodeCertificate(X509Certificate certificate) throws CertificateException {
+    public static String encodeCertificate(X509Certificate certificate) throws CertificateException {
 
         if (certificate != null) {
             return Base64.encode(certificate.getEncoded());
@@ -1330,19 +1017,6 @@ public class CertificateValidationUtil {
         throw new IllegalArgumentException("Invalid validator name provided : " + name);
     }
 
-    private static Registry getGovernanceRegistry(String tenantDomain) throws CertificateValidationException {
-
-        Registry registry;
-        try {
-            registry = CertValidationDataHolder.getInstance().getRegistryService().getGovernanceSystemRegistry(
-                    CertValidationDataHolder.getInstance().getRealmService().getTenantManager()
-                            .getTenantId(tenantDomain));
-        } catch (UserStoreException | RegistryException e) {
-            throw new CertificateValidationException("Error while get tenant registry.", e);
-        }
-        return registry;
-    }
-
     private static String getJCEProvider() {
 
         String provider = ServerConfiguration.getInstance().getFirstProperty(ServerConstants.JCE_PROVIDER);
@@ -1358,7 +1032,7 @@ public class CertificateValidationUtil {
      * @param cert X509Certificate
      * @return true if the certificate is self-signed, false otherwise
      */
-    private static boolean isSelfSignedCert(X509Certificate cert) {
+    public static boolean isSelfSignedCert(X509Certificate cert) {
 
         try {
             PublicKey key = cert.getPublicKey();
@@ -1371,664 +1045,34 @@ public class CertificateValidationUtil {
     }
 
     private static void addDefaultValidatorConfigToConfigStore(OMElement validatorsElement, String tenantDomain)
-            throws CertificateValidationException {
+            throws CertificateValidationManagementException {
 
         List<Validator> defaultValidatorConfig = getDefaultValidatorConfig(validatorsElement);
-        for (Validator validator : defaultValidatorConfig) {
-            String displayName = validator.getDisplayName();
-            if (log.isDebugEnabled()) {
-                log.debug("Adding the configurations for validator: " + displayName);
-            }
 
-            org.wso2.carbon.identity.configuration.mgt.core.model.Resource validatorResource =
-                    buildResourceFromValidator(validator, getNormalizedName(displayName));
-            addResource(validatorResource);
-        }
+        certificateValidationPersistenceManager.addValidators(defaultValidatorConfig, tenantDomain);
     }
 
     /**
-     * Builds a Resource object from the Validator configuration.
+     * Generate a certificate hash to identify a certificate uniquely.
      *
-     * @param validator    Validator configuration object.
-     * @param resourceName Resource name.
-     * @return A new Resource object with the validator's properties.
+     * @param cert X509Certificate
+     * @return String
+     * @throws Exception Error when generating certificate hash
      */
-    private static org.wso2.carbon.identity.configuration.mgt.core.model.Resource buildResourceFromValidator(
-            Validator validator, String resourceName) {
+    public static String generateCertificateHash(X509Certificate cert) throws NoSuchAlgorithmException {
 
-        org.wso2.carbon.identity.configuration.mgt.core.model.Resource resource =
-                new org.wso2.carbon.identity.configuration.mgt.core.model.Resource(resourceName,
-                        VALIDATOR_RESOURCE_TYPE);
-        resource.setHasAttribute(true);
-        createAttributeList(validator, resource);
+        String identifier = cert.getIssuerX500Principal().getName() + "#" + cert.getSerialNumber().toString(16);
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        byte[] hashBytes = digest.digest(identifier.getBytes(StandardCharsets.UTF_8));
 
-        return resource;
+        return bytesToHex(hashBytes);
     }
 
-    private static void createAttributeList(Validator validator,
-                                            org.wso2.carbon.identity.configuration.mgt.core.model.Resource resource) {
-
-        List<Attribute> attributes = new ArrayList<>();
-        attributes.add(new Attribute(VALIDATOR_CONF_NAME, validator.getName()));
-        attributes.add(new Attribute(VALIDATOR_CONF_ENABLE,
-                Boolean.toString(validator.isEnabled())));
-        attributes.add(new Attribute(VALIDATOR_CONF_PRIORITY,
-                Integer.toString(validator.getPriority())));
-        attributes.add(new Attribute(VALIDATOR_CONF_FULL_CHAIN_VALIDATION,
-                Boolean.toString(validator.isFullChainValidationEnabled())));
-        attributes.add(new Attribute(VALIDATOR_CONF_RETRY_COUNT,
-                Integer.toString(validator.getRetryCount())));
-        resource.setAttributes(attributes);
-    }
-
-    /**
-     * Adds specified resource to the configuration management system.
-     *
-     * @param resource The resource object to add.
-     * @throws CertificateValidationException If an error occurs while adding the resource.
-     */
-    private static void addResource(
-            org.wso2.carbon.identity.configuration.mgt.core.model.Resource resource)
-            throws CertificateValidationException {
-
-        try {
-            CertValidationDataHolder.getInstance().getConfigurationManager()
-                    .addResource(resource.getResourceType(), resource);
-        } catch (ConfigurationManagementException e) {
-            if (ERROR_CODE_RESOURCE_ALREADY_EXISTS.getCode().equals(e.getErrorCode())) {
-                log.debug("Resource already exists in the tenant config store.");
-            } else {
-                throw new CertificateValidationException("Error while adding validator configurations.", e);
-            }
+    private static String bytesToHex(byte[] bytes) {
+        StringBuilder hexString = new StringBuilder();
+        for (byte b : bytes) {
+            hexString.append(String.format("%02X", b));
         }
-    }
-
-    /**
-     * Converts a Resource object into a Validator object.
-     *
-     * @param resource The resource object to convert.
-     * @return A Validator object populated with resource attributes.
-     */
-    private static Validator resourceToValidatorObject(
-            org.wso2.carbon.identity.configuration.mgt.core.model.Resource resource) {
-
-        Validator validator = new Validator();
-
-        // Extract attributes from the resource.
-        List<Attribute> attributes = resource.getAttributes();
-        validator.setDisplayName(resource.getResourceName());
-        if (attributes != null) {
-            for (Attribute attribute : attributes) {
-                String key = attribute.getKey();
-                String value = attribute.getValue();
-
-                switch (key) {
-                    case VALIDATOR_CONF_NAME:
-                        validator.setName(value);
-                        break;
-                    case VALIDATOR_CONF_ENABLE:
-                        validator.setEnabled(Boolean.parseBoolean(value));
-                        break;
-                    case VALIDATOR_CONF_PRIORITY:
-                        validator.setPriority(Integer.parseInt(value));
-                        break;
-                    case VALIDATOR_CONF_FULL_CHAIN_VALIDATION:
-                        validator.setFullChainValidationEnabled(Boolean.parseBoolean(value));
-                        break;
-                    case VALIDATOR_CONF_RETRY_COUNT:
-                        validator.setRetryCount(Integer.parseInt(value));
-                        break;
-                    default:
-                        // Ignore unknown attributes.
-                        break;
-                }
-            }
-        }
-        return validator;
-    }
-
-    /**
-     * Get validators from the configuration store.
-     *
-     * @param tenantDomain Tenant Domain.
-     * @return List of Validator.
-     * @throws ConfigurationManagementException Error when getting resource.
-     */
-    public static List<Validator> getValidatorsFromConfigStore(String tenantDomain)
-            throws ConfigurationManagementException {
-
-        List<Validator> validators = new ArrayList<>();
-        Resources resources = CertValidationDataHolder.getInstance().getConfigurationManager()
-                .getResourcesByType(IdentityTenantUtil.getTenantId(tenantDomain), VALIDATOR_RESOURCE_TYPE);
-        resources.getResources().forEach(resource -> validators.add(resourceToValidatorObject(resource)));
-        return validators;
-    }
-
-    /**
-     * Get validator from the configuration store by name.
-     *
-     * @param tenantDomain Tenant Domain.
-     * @param name         Validator name.
-     * @return Validator object.
-     * @throws CertificateValidationException Error when getting validator.
-     */
-    public static Optional<Validator> getValidatorFromConfigStoreByName(String tenantDomain, String name)
-            throws CertificateValidationException {
-
-        try {
-            org.wso2.carbon.identity.configuration.mgt.core.model.Resource resource =
-                    CertValidationDataHolder.getInstance().getConfigurationManager()
-                            .getResourceByTenantId(IdentityTenantUtil.getTenantId(tenantDomain),
-                                    VALIDATOR_RESOURCE_TYPE, name);
-            if (resource == null) {
-                return Optional.empty();
-            }
-            return Optional.of(resourceToValidatorObject(resource));
-        } catch (ConfigurationManagementException e) {
-            throw new CertificateValidationException("Error while fetching validator configurations.", e);
-        }
-    }
-
-    /**
-     * Update validator in the configuration store.
-     *
-     * @param tenantDomain Tenant Domain.
-     * @param validator    Validator.
-     * @return Validator object.
-     * @throws CertificateValidationException Error when updating validator.
-     */
-    public static Optional<Validator> updateValidatorInConfigStore(String tenantDomain, Validator validator)
-            throws CertificateValidationException {
-
-        try {
-            org.wso2.carbon.identity.configuration.mgt.core.model.Resource resource =
-                    CertValidationDataHolder.getInstance().getConfigurationManager()
-                            .getResourceByTenantId(IdentityTenantUtil.getTenantId(tenantDomain),
-                                    VALIDATOR_RESOURCE_TYPE, validator.getDisplayName());
-            if (resource == null) {
-                return Optional.empty();
-            }
-            createAttributeList(validator, resource);
-            org.wso2.carbon.identity.configuration.mgt.core.model.Resource updatedResource =
-                    CertValidationDataHolder.getInstance().getConfigurationManager()
-                            .replaceResource(VALIDATOR_RESOURCE_TYPE, resource);
-            return Optional.of(resourceToValidatorObject(updatedResource));
-        } catch (ConfigurationManagementException e) {
-            throw new CertificateValidationException("Error while fetching validator configurations.", e);
-        }
-    }
-
-    /**
-     * Get the certificate list from the configuration store.
-     *
-     * @param tenantDomain Tenant Domain.
-     * @return List of CACertificateInfo.
-     * @throws CertificateValidationException Error when getting certificate.
-     */
-    public static Optional<List<CACertificateInfo>> getCertificateListFromConfigurationStore(String tenantDomain)
-            throws CertificateValidationException {
-
-        try {
-            org.wso2.carbon.identity.configuration.mgt.core.model.Resource resource =
-                    CertValidationDataHolder.getInstance().getConfigurationManager()
-                            .getResourceByTenantId(IdentityTenantUtil.getTenantId(tenantDomain),
-                                    X509_CA_CERT_RESOURCE_TYPE, CERTS);
-            if (resource == null) {
-                return Optional.empty();
-            }
-            InputStream inputStream = getResourceFileInputStream(resource);
-            if (inputStream == null) {
-                return Optional.empty();
-            }
-            return Optional.of(parseCertificateList(inputStream, tenantDomain));
-        } catch (IOException | ConfigurationManagementException | CertificateException | CertificateMgtException e) {
-            throw new CertificateValidationException("Error while processing the resource", e);
-        }
-    }
-
-    private static InputStream getResourceFileInputStream
-            (org.wso2.carbon.identity.configuration.mgt.core.model.Resource resource)
-            throws ConfigurationManagementException {
-
-        List<ResourceFile> resourceFiles = resource.getFiles();
-        if (resourceFiles == null || resourceFiles.isEmpty()) {
-            log.debug("Resource files are empty for certificates in tenant: " + resource.getTenantDomain());
-            return null;
-        }
-        ResourceFile resourceFile = resourceFiles.get(0);
-        return resourceFile != null ? CertValidationDataHolder.getInstance().getConfigurationManager()
-                .getFileById(X509_CA_CERT_RESOURCE_TYPE, CERTS, resourceFile.getId()) : null;
-    }
-
-    private static List<CACertificateInfo> parseCertificateList(InputStream inputStream, String tenantDomain)
-            throws IOException, CertificateMgtException, CertificateException {
-
-        List<CACertificateInfo> certificateList = new ArrayList<>();
-        String fileContent = convertInputStreamToString(inputStream);
-        IssuerDNMap issuerDNMap = ModelSerializer.deserializeIssuerDNMap(fileContent);
-        for (Map.Entry<String, List<CertObject>> entry : issuerDNMap.getIssuerCertMap().entrySet()) {
-            for (CertObject certObject : entry.getValue()) {
-                certificateList.add(convertCertObjectToCACertificateInfo(certObject, tenantDomain));
-            }
-        }
-        return certificateList;
-    }
-
-    private static CACertificateInfo convertCertObjectToCACertificateInfo(CertObject certObject, String tenantDomain)
-            throws CertificateMgtException, CertificateException {
-
-        Certificate certificate = CertValidationDataHolder.getInstance()
-                .getCertificateManagementService()
-                .getCertificate(certObject.getCertId(), tenantDomain);
-        X509Certificate x509Certificate = decodeCertificate(certificate.getCertificateContent());
-
-        return getCACertificateInfo(x509Certificate, certObject);
-    }
-
-    /**
-     * Get the certificate from the configuration store by serial number.
-     *
-     * @param caCertificate X509Certificate.
-     * @param certObject    CertObject.
-     * @return CACertificateInfo.
-     */
-    public static CACertificateInfo getCACertificateInfo(X509Certificate caCertificate, CertObject certObject) {
-
-        CACertificateInfo caCertificateInfo = new CACertificateInfo();
-        caCertificateInfo.setCertId(certObject.getCertId());
-        caCertificateInfo.setIssuerDN(getNormalizedName(caCertificate.getIssuerDN().getName()));
-        caCertificateInfo.setSerialNumber(getNormalizedName(caCertificate.getSerialNumber().toString()));
-        caCertificateInfo.setCrlUrls(certObject.getCrlUrls());
-        caCertificateInfo.setOcspUrls(certObject.getOcspUrls());
-        return caCertificateInfo;
-    }
-
-    /**
-     * Add a certificate in the configuration store.
-     *
-     * @param tenantDomain Tenant Domain
-     * @param certificate  X509Certificate
-     * @return CertObject
-     * @throws CertificateValidationException Error when adding certificate
-     * @throws CertificateException           Error when encoding certificate
-     * @throws CertificateMgtException        Error when adding certificate
-     */
-    public static Optional<CertObject> addCertificateInConfigurationStore(String tenantDomain,
-                                                                          X509Certificate certificate)
-            throws CertificateValidationException, CertificateException, CertificateMgtException {
-
-        try {
-            org.wso2.carbon.identity.configuration.mgt.core.model.Resource resource = CertValidationDataHolder
-                    .getInstance().getConfigurationManager()
-                    .getResourceByTenantId(IdentityTenantUtil.getTenantId(tenantDomain),
-                            X509_CA_CERT_RESOURCE_TYPE, CERTS);
-            InputStream inputStream = getResourceFileInputStream(resource);
-            if (inputStream == null) {
-                return Optional.empty();
-            }
-
-            IssuerDNMap issuerDNMap = ModelSerializer.deserializeIssuerDNMap(convertInputStreamToString(inputStream));
-            String issuerDN = getNormalizedName(certificate.getIssuerDN().getName());
-            String serialNumber = getNormalizedName(certificate.getSerialNumber().toString());
-
-            List<String> ocspUrls = getValidationUrls(certificate, tenantDomain, OCSP_VALIDATOR);
-            List<String> crlUrls = getValidationUrls(certificate, tenantDomain, CRL_VALIDATOR);
-
-            Certificate newCert = new Certificate.Builder()
-                    .name(X509_CERT_PREFIX + UUID.randomUUID())
-                    .certificateContent(encodeCertificate(certificate))
-                    .build();
-            String certId = CertValidationDataHolder.getInstance().getCertificateManagementService()
-                    .addCertificate(newCert, tenantDomain);
-
-            CertObject certObject = new CertObject();
-            certObject.setCertId(certId);
-            certObject.setSerialNumber(serialNumber);
-            certObject.setCrlUrls(crlUrls);
-            certObject.setOcspUrls(ocspUrls);
-
-            if (issuerDNMap.getIssuerCertMap().containsKey(issuerDN)) {
-                List<CertObject> certList = issuerDNMap.getIssuerCertMap().get(issuerDN);
-
-                boolean serialExists = certList.stream()
-                        .anyMatch(cert -> getNormalizedName(cert.getSerialNumber()).equals(serialNumber));
-
-                if (serialExists) {
-                    throw new CertificateValidationException("Certificate with the serial number: " + serialNumber +
-                            " already exists for the issuerDN: " + issuerDN);
-                } else {
-                    log.debug("Adding new certificate with serial number: " + serialNumber + " for issuerDN: " +
-                            issuerDN);
-                    certList.add(certObject);
-                    issuerDNMap.getIssuerCertMap().put(issuerDN, certList);
-                }
-            } else {
-                // Add new issuerDN with the cert
-                List<CertObject> newCertList = new ArrayList<>();
-                newCertList.add(certObject);
-                issuerDNMap.getIssuerCertMap().put(issuerDN, newCertList);
-            }
-            saveUpdatedResource(resource, issuerDNMap);
-            return Optional.of(certObject);
-        } catch (ConfigurationManagementException | IOException | CertificateException | CertificateMgtException e) {
-            throw new CertificateValidationException("Error while processing the resource", e);
-        }
-    }
-
-    /**
-     * update the certificate in the configuration store by certificate id.
-     *
-     * @param certificateId certificate id.
-     * @param certificate   X509Certificate.
-     * @param tenantDomain  tenant domain.
-     * @return CertObject.
-     * @throws CertificateValidationException Error when updating certificate.
-     */
-    public static Optional<CertObject> updateCertificateInConfigurationStoreByCertificateId(String certificateId,
-                                                                                            X509Certificate certificate,
-                                                                                            String tenantDomain)
-            throws CertificateValidationException {
-
-        try {
-            org.wso2.carbon.identity.configuration.mgt.core.model.Resource resource = CertValidationDataHolder
-                    .getInstance().getConfigurationManager()
-                    .getResourceByTenantId(IdentityTenantUtil.getTenantId(tenantDomain),
-                            X509_CA_CERT_RESOURCE_TYPE, CERTS);
-            InputStream inputStream = getResourceFileInputStream(resource);
-            if (inputStream == null) {
-                return Optional.empty();
-            }
-
-            IssuerDNMap issuerDNMap = ModelSerializer.deserializeIssuerDNMap(convertInputStreamToString(inputStream));
-            String issuerDN = getNormalizedName(certificate.getIssuerDN().getName());
-            String serialNumber = getNormalizedName(certificate.getSerialNumber().toString());
-
-            List<String> ocspUrls = getValidationUrls(certificate, tenantDomain, OCSP_VALIDATOR);
-            List<String> crlUrls = getValidationUrls(certificate, tenantDomain, CRL_VALIDATOR);
-
-            boolean certExistsInMap = false;
-            String previousIssuer = null;
-
-            // Check if certificateId exists anywhere in the issuer map
-            for (Map.Entry<String, List<CertObject>> entry : issuerDNMap.getIssuerCertMap().entrySet()) {
-                for (CertObject cert : entry.getValue()) {
-                    if (cert.getCertId().equals(certificateId)) {
-                        certExistsInMap = true;
-                        previousIssuer = entry.getKey();
-                        break;
-                    }
-                }
-                if (certExistsInMap) {
-                    break;
-                }
-            }
-
-            // If the certId is not found in the entire map, throw an error
-            if (!certExistsInMap) {
-                throw new CertificateValidationException("Certificate with certId: " + certificateId +
-                        " does not exist in the issuer map.");
-            }
-
-            // Get the list of certificates for the given issuer
-            List<CertObject> certList = issuerDNMap.getIssuerCertMap().getOrDefault(issuerDN, new ArrayList<>());
-            int certIndex = -1;
-
-            // Check if the certId exists within this issuer
-            for (int i = 0; i < certList.size(); i++) {
-                if (certList.get(i).getCertId().equals(certificateId)) {
-                    certIndex = i;
-                    break;
-                }
-            }
-
-            // Create an updated CertObject
-            CertObject updatedCertObject = new CertObject();
-            updatedCertObject.setCertId(certificateId);
-            updatedCertObject.setSerialNumber(serialNumber);
-            updatedCertObject.setCrlUrls(crlUrls);
-            updatedCertObject.setOcspUrls(ocspUrls);
-
-            if (certIndex != -1) {
-                // Case 2: Cert ID exists under the same issuer → Update the certificate
-                certList.set(certIndex, updatedCertObject);
-            } else {
-                // Case 3: Cert ID does not exist under this issuer → Add as a new cert
-                certList.add(updatedCertObject);
-
-                // Case 4: Remove the cert from the previous issuer (if different)
-                if (!issuerDN.equals(previousIssuer) && previousIssuer != null) {
-                    List<CertObject> previousCertList = issuerDNMap.getIssuerCertMap().get(previousIssuer);
-                    previousCertList.removeIf(cert -> cert.getCertId().equals(certificateId));
-
-                    // If no certificates remain for the old issuer, remove the issuer entry
-                    if (previousCertList.isEmpty()) {
-                        issuerDNMap.getIssuerCertMap().remove(previousIssuer);
-                    } else {
-                        // Otherwise, just update the cert list without removing the issuer
-                        issuerDNMap.getIssuerCertMap().put(previousIssuer, previousCertList);
-                    }
-                }
-            }
-
-            // Update the issuer map with the modified cert list
-            issuerDNMap.getIssuerCertMap().put(issuerDN, certList);
-
-            saveUpdatedResource(resource, issuerDNMap);
-            return Optional.of(updatedCertObject);
-        } catch (ConfigurationManagementException | IOException e) {
-            throw new CertificateValidationException("Error while processing the resource", e);
-        }
-    }
-
-    /**
-     * Update the CA certificate in the certificate manager.
-     *
-     * @param certificateId Certificate id
-     * @param certificate   X509Certificate
-     * @param tenantDomain  Tenant domain
-     * @return X509Certificate
-     * @throws CertificateValidationException Error when updating certificate
-     */
-    public static X509Certificate updateCACertificateInCertificateManager(String certificateId,
-                                                                          X509Certificate certificate,
-                                                                          String tenantDomain)
-            throws CertificateValidationException {
-
-        try {
-            CertValidationDataHolder.getInstance()
-                    .getCertificateManagementService()
-                    .getCertificate(certificateId, tenantDomain);
-            CertValidationDataHolder.getInstance()
-                    .getCertificateManagementService()
-                    .updateCertificateContent(certificateId, encodeCertificate(certificate), tenantDomain);
-            log.debug("Successfully updated certificate with the id: " + certificateId + " in certificate manager.");
-            return certificate;
-        } catch (CertificateMgtException e) {
-            if (CertificateMgtErrors.ERROR_CERTIFICATE_DOES_NOT_EXIST.getCode().equals(e.getErrorCode())) {
-                throw new CertificateValidationException
-                        ("Certificate with the id: " + certificateId + " does not exist.", e);
-            }
-            throw new CertificateValidationException("Error when updating certificate in certificate manager.", e);
-        } catch (CertificateException e) {
-            throw new CertificateValidationException("Error when encoding certificate.", e);
-        }
-    }
-
-    /**
-     * Delete a certificate in the configuration store by certificate id.
-     *
-     * @param certificateId Certificate Id
-     * @param tenantDomain  Tenant Domain
-     * @return CertObject
-     * @throws CertificateValidationException Error when deleting certificate
-     */
-    public static Optional<CertObject> deleteCertificateInConfigurationStoreByCertificateId(String certificateId,
-                                                                                            String tenantDomain)
-            throws CertificateValidationException {
-
-        try {
-            org.wso2.carbon.identity.configuration.mgt.core.model.Resource resource =
-                    CertValidationDataHolder.getInstance().getConfigurationManager()
-                            .getResourceByTenantId(IdentityTenantUtil.getTenantId(tenantDomain),
-                                    X509_CA_CERT_RESOURCE_TYPE, CERTS);
-            InputStream inputStream = getResourceFileInputStream(resource);
-            if (inputStream == null) {
-                return Optional.empty();
-            }
-
-            IssuerDNMap issuerDNMap = ModelSerializer.deserializeIssuerDNMap(convertInputStreamToString(inputStream));
-
-            for (Map.Entry<String, List<CertObject>> entry : issuerDNMap.getIssuerCertMap().entrySet()) {
-                List<CertObject> certList = entry.getValue();
-                if (certList.removeIf(cert -> cert.getCertId().equals(certificateId))) {
-                    if (certList.isEmpty()) {
-                        issuerDNMap.getIssuerCertMap().remove(entry.getKey());
-                    }
-                    saveUpdatedResource(resource, issuerDNMap);
-                    return Optional.of(new CertObject());
-                }
-            }
-            return Optional.empty();
-        } catch (IOException | ConfigurationManagementException e) {
-            throw new CertificateValidationException("Error while processing the resource", e);
-        }
-    }
-
-    /**
-     * Delete the ca certificate from the certificate manager.
-     *
-     * @param certificateId Certificate id
-     * @param tenantDomain  Tenant domain
-     * @throws CertificateValidationException Error when deleting certificate
-     */
-    public static void deleteCACertificateFromCertificateManager(String certificateId,
-                                                                 String tenantDomain)
-            throws CertificateValidationException {
-
-        try {
-            CertValidationDataHolder.getInstance()
-                    .getCertificateManagementService()
-                    .deleteCertificate(certificateId, tenantDomain);
-        } catch (CertificateMgtException e) {
-            if (CertificateMgtErrors.ERROR_CERTIFICATE_DOES_NOT_EXIST.getCode().equals(e.getErrorCode())) {
-                throw new CertificateValidationException
-                        ("Certificate with the id: " + certificateId + " does not exist.", e);
-            }
-            throw new CertificateValidationException("Error when getting certificate from certificate manager.", e);
-        }
-    }
-
-    private static List<String> getValidationUrls(X509Certificate certificate, String tenantDomain,
-                                                  String validatorType)
-            throws ConfigurationManagementException, CertificateValidationException {
-
-        List<String> urls = new ArrayList<>();
-        if (!isSelfSignedCert(certificate)) {
-            for (Validator validator : getValidatorsFromConfigStore(tenantDomain)) {
-                if (validator.isEnabled() && validatorType.equals(validator.getDisplayName())) {
-                    urls = OCSP_VALIDATOR.equals(validatorType) ? getAIALocations(certificate) :
-                            getCRLUrls(certificate);
-                }
-            }
-        }
-        return urls;
-    }
-
-    private static void saveUpdatedResource
-            (org.wso2.carbon.identity.configuration.mgt.core.model.Resource resource, IssuerDNMap issuerDNMap)
-            throws IOException, ConfigurationManagementException {
-
-        String serializedContent = ModelSerializer.serializeIssuerDNMap(issuerDNMap);
-        InputStream inputStreamUpdated = new ByteArrayInputStream(serializedContent.getBytes(StandardCharsets.UTF_8));
-
-        ResourceFile resourceFileUpdated = new ResourceFile();
-        resourceFileUpdated.setName(X509_CA_CERT_FILE);
-        resourceFileUpdated.setInputStream(inputStreamUpdated);
-        resource.getFiles().set(0, resourceFileUpdated);
-
-        CertValidationDataHolder.getInstance().getConfigurationManager()
-                .replaceResource(X509_CA_CERT_RESOURCE_TYPE, resource);
-    }
-
-    /**
-     * Get certificate from the configuration store by certificate id.
-     *
-     * @param tenantDomain  Tenant Domain
-     * @param certificateId Certificate Id
-     * @return CACertificate
-     * @throws CertificateValidationException Error when getting certificate
-     */
-    public static Optional<CACertificate> getCertificateFromConfigurationStoreByCertificateId(String tenantDomain,
-                                                                                              String certificateId)
-            throws CertificateValidationException {
-
-        try {
-            org.wso2.carbon.identity.configuration.mgt.core.model.Resource resource =
-                    CertValidationDataHolder.getInstance().getConfigurationManager().getResourceByTenantId
-                            (IdentityTenantUtil.getTenantId(tenantDomain), X509_CA_CERT_RESOURCE_TYPE, CERTS);
-            List<ResourceFile> resourceFiles = resource.getFiles();
-            if (resourceFiles == null || resourceFiles.isEmpty()) {
-                log.debug("Resource files are empty for certificates in tenant: " + resource.getTenantDomain());
-                return Optional.empty();
-            }
-
-            ResourceFile resourceFile = resourceFiles.get(0);
-            if (resourceFile == null) {
-                log.debug("Resource file is null for certificates in tenant: " + resource.getTenantDomain());
-                return Optional.empty();
-            }
-
-            InputStream inputStream = CertValidationDataHolder.getInstance()
-                    .getConfigurationManager()
-                    .getFileById(X509_CA_CERT_RESOURCE_TYPE, CERTS, resourceFile.getId());
-
-            if (inputStream == null) {
-                log.debug("InputStream is null for the file in resource.");
-                return Optional.empty();
-            }
-
-            String fileContent = convertInputStreamToString(inputStream);
-            IssuerDNMap issuerDNMap = ModelSerializer.deserializeIssuerDNMap(fileContent);
-
-            for (Map.Entry<String, List<CertObject>> entry : issuerDNMap.getIssuerCertMap().entrySet()) {
-                List<CertObject> certList = entry.getValue();
-                Optional<CertObject> certObject = certList.stream()
-                        .filter(cert -> cert.getCertId().equals(certificateId))
-                        .findFirst();
-
-                if (certObject.isPresent()) {
-                    return Optional.of(new CACertificate(certObject.get().getCrlUrls(),
-                            certObject.get().getOcspUrls(),
-                            getCACertificateFromCertificateManager(certificateId, tenantDomain)));
-                }
-            }
-            return Optional.empty();
-        } catch (ConfigurationManagementException e) {
-            throw new CertificateValidationException("Error while processing the resource", e);
-        } catch (IOException e) {
-            throw new CertificateValidationException("Error while reading the file content", e);
-        }
-    }
-
-    private static X509Certificate getCACertificateFromCertificateManager(String certificateId,
-                                                                          String tenantDomain)
-            throws CertificateValidationException {
-
-        try {
-            Certificate certificate = CertValidationDataHolder.getInstance()
-                    .getCertificateManagementService()
-                    .getCertificate(certificateId, tenantDomain);
-
-            return decodeCertificate(certificate.getCertificateContent());
-        } catch (CertificateMgtException e) {
-            log.debug("Error when getting certificate from certificate manager.", e);
-            if (CertificateMgtErrors.ERROR_CERTIFICATE_DOES_NOT_EXIST.getCode().equals(e.getErrorCode())) {
-                throw new CertificateValidationException
-                        ("Certificate with the id: " + certificateId + " does not exist.", e);
-            }
-            throw new CertificateValidationException("Error when getting certificate from certificate manager.", e);
-        } catch (CertificateException e) {
-            throw new CertificateValidationException("Error when decoding certificate.", e);
-        }
+        return hexString.toString();
     }
 }

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/X509CertificateValidationConstants.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/X509CertificateValidationConstants.java
@@ -28,6 +28,7 @@ public class X509CertificateValidationConstants {
     public static final String X509_CERT_PREFIX = "X509_CERT_";
     public static final String X509_CA_CERT_RESOURCE_TYPE = "X509_REVOCATION_VALIDATION_CA";
     public static final String CERTS = "CERTS";
+    public static final String CERTFICATE_ID = "certificateId";
     public static final String CERT_VALIDATION_CONF_DIRECTORY = "security";
     public static final String CERT_VALIDATION_CONF_FILE = "certificate-validation.xml";
     public static final String VALIDATOR_CONF = "Validators";

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/X509CertificateValidationConstants.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/X509CertificateValidationConstants.java
@@ -23,10 +23,10 @@ package org.wso2.carbon.identity.x509Certificate.validation;
  */
 public class X509CertificateValidationConstants {
 
-    public static final String VALIDATOR_RESOURCE_TYPE = "X509_VALIDATOR";
-    public static final String X509_CA_CERT_FILE = "x509_ca_cert_file";
-    public static final String X509_CERT_PREFIX = "X509_CERT_";
-    public static final String X509_CA_CERT_RESOURCE_TYPE = "X509_REVOCATION_VALIDATION_CA";
+    public static final String VALIDATOR_RESOURCE_TYPE = "CERTIFICATE_VALIDATOR";
+    public static final String X509_CA_CERT_FILE = "ca_cert_file";
+    public static final String X509_CERT_PREFIX = "CA_CERT_";
+    public static final String X509_CA_CERT_RESOURCE_TYPE = "CERTIFICATE_REVOCATION_VALIDATION_CA";
     public static final String CERTS = "CERTS";
     public static final String CERTFICATE_ID = "certificateId";
     public static final String CERT_VALIDATION_CONF_DIRECTORY = "security";

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/constant/error/ErrorMessage.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/constant/error/ErrorMessage.java
@@ -32,6 +32,8 @@ public enum ErrorMessage {
             "No CA Certificate is configured on the given tenant %s."),
     ERROR_CERTIFICATE_DOES_NOT_EXIST("60004", "Unable to perform the operation.", "Certificate " +
             "with the id: %s does not exist in tenant %s."),
+    ERROR_CA_CERTIFICATE_ALREADY_EXISTS("60005", "Unable to perform the operation.",
+            "CA Certificate with the serial number: %s already exists in tenant %s."),
 
     // Server errors.
     ERROR_WHILE_RETRIEVING_VALIDATORS("65001", "Error while retrieving validators.",
@@ -49,7 +51,13 @@ public enum ErrorMessage {
     ERROR_WHILE_RETRIEVING_CA_CERTIFICATE_BY_ID("65007", "Unable to perform the operation.",
             "Error while retrieving CA Certificate by ID %s from tenant %s."),
     ERROR_WHILE_DELETING_CA_CERTIFICATE("65008", "Error while deleting CA Certificate.", "Error " +
-            "while deleting CA Certificate from the system.");
+            "while deleting CA Certificate from the system."),
+    ERROR_WHILE_ADDING_VALIDATORS("65009", "Error while adding Validator.",
+            "Error while persisting Validator in the tenant %s."),
+    ERROR_WHILE_RETIREVING_CA_CERTIFICATE_BY_ISSUER("65010", "Unable to perform the operation.",
+            "Error while retrieving CA Certificate by issuer %s from tenant %s."),
+    ERROR_WHILE_ADDING_CA_CERTIFICATES("65011", "Error while adding CA Certificates.",
+            "Error while persisting CA Certificates in the tenant %s.");
 
     private final String code;
     private final String message;

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/model/CertObject.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/model/CertObject.java
@@ -30,6 +30,7 @@ public class CertObject {
     private List<String> ocspUrls;
     private String certId;
     private String serialNumber;
+    private String certificatePersistedId;
 
     public List<String> getCrlUrls() {
 
@@ -69,6 +70,16 @@ public class CertObject {
     public void setSerialNumber(String serialNumber) {
 
         this.serialNumber = serialNumber;
+    }
+
+    public String getCertificatePersistedId() {
+
+        return certificatePersistedId;
+    }
+
+    public void setCertificatePersistedId(String certificatePersistedId) {
+
+        this.certificatePersistedId = certificatePersistedId;
     }
 
     @Override

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/persistence/CertificateValidationPersistenceManager.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/persistence/CertificateValidationPersistenceManager.java
@@ -51,6 +51,14 @@ public interface CertificateValidationPersistenceManager {
     void addCACertificates(List<Validator> validators, List<X509Certificate> trustedCertificates,
                            String tenantDomain) throws CertificateValidationManagementException;
 
+    /**
+     * Get CA Certificates by issuer.
+     *
+     * @param issuerDN     Issuer DN.
+     * @param tenantDomain Tenant Domain.
+     * @return List of CA certificates.
+     * @throws CertificateValidationManagementException If an error occurs while getting the CA certificates.
+     */
     List<CACertificate> getCACertsByIssuer(String issuerDN, String tenantDomain)
             throws CertificateValidationManagementException;
 

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/persistence/CertificateValidationPersistenceManager.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/persistence/CertificateValidationPersistenceManager.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.x509Certificate.validation.persistence;
+
+import java.security.cert.X509Certificate;
+import java.util.List;
+import org.wso2.carbon.identity.x509Certificate.validation.exception.CertificateValidationManagementException;
+import org.wso2.carbon.identity.x509Certificate.validation.model.CACertificate;
+import org.wso2.carbon.identity.x509Certificate.validation.model.CACertificateInfo;
+import org.wso2.carbon.identity.x509Certificate.validation.model.Validator;
+
+/**
+ * This interface supports the persistence/storage related logics of certificates and validators.
+ */
+public interface CertificateValidationPersistenceManager {
+
+    /**
+     * Add default validators.
+     *
+     * @param validators  List of validators.
+     * @param tenatDomain Tenant Domain.
+     * @throws CertificateValidationManagementException If an error occurs while adding the default validators.
+     */
+    void addValidators(List<Validator> validators, String tenatDomain)
+            throws CertificateValidationManagementException;
+
+    /**
+     * Add CA Certificates.
+     *
+     * @param validators          List of validators.
+     * @param trustedCertificates List of trusted certificates.
+     * @param tenantDomain        Tenant Domain.
+     * @throws CertificateValidationManagementException If an error occurs while adding the CA certificates.
+     */
+    void addCACertificates(List<Validator> validators, List<X509Certificate> trustedCertificates,
+                           String tenantDomain) throws CertificateValidationManagementException;
+
+    List<CACertificate> getCACertsByIssuer(String issuerDN, String tenantDomain)
+            throws CertificateValidationManagementException;
+
+    /**
+     * Get validators.
+     *
+     * @param tenantDomain Tenant Id.
+     * @return List of validators.
+     * @throws CertificateValidationManagementException If an error occurs while getting the validators.
+     */
+    List<Validator> getValidators(String tenantDomain) throws CertificateValidationManagementException;
+
+    /**
+     * Get the validator by name.
+     *
+     * @param name         Name of the validator.
+     * @param tenantDomain Tenant Id.
+     * @return Validator.
+     * @throws CertificateValidationManagementException If an error occurs while getting the validator.
+     */
+    Validator getValidator(String name, String tenantDomain) throws CertificateValidationManagementException;
+
+    /**
+     * Update the validator.
+     *
+     * @param validator    Validator.
+     * @param tenantDomain Tenant Id.
+     * @return Updated validator.
+     * @throws CertificateValidationManagementException If an error occurs while updating the validator.
+     */
+    Validator updateValidator(Validator validator, String tenantDomain) throws CertificateValidationManagementException;
+
+    /**
+     * Get CA Certificates.
+     *
+     * @param tenantDomain Tenant Id.
+     * @return List of CA certificates.
+     * @throws CertificateValidationManagementException If an error occurs while getting the CA certificates.
+     */
+    List<CACertificateInfo> getCACertificates(String tenantDomain) throws CertificateValidationManagementException;
+
+    /**
+     * Add CA Certificate.
+     *
+     * @param encodedCertificate Base64 Encoded CA Certificate.
+     * @param tenantDomain       Tenant Id.
+     * @return Added CA Certificate Info.
+     * @throws CertificateValidationManagementException If an error occurs while adding the CA certificate.
+     */
+    CACertificateInfo addCACertificate(String encodedCertificate, String tenantDomain)
+            throws CertificateValidationManagementException;
+
+    /**
+     * Get CA Certificate.
+     *
+     * @param certificateId Certificate Id.
+     * @param tenantDomain  Tenant Id.
+     * @return CA Certificate Info.
+     * @throws CertificateValidationManagementException If an error occurs while getting the CA certificate.
+     */
+    CACertificateInfo getCACertificate(String certificateId, String tenantDomain)
+            throws CertificateValidationManagementException;
+
+    /**
+     * Update CA Certificate.
+     *
+     * @param certificateId      Certificate Id.
+     * @param encodedCertificate Base64 Encoded CA Certificate.
+     * @param tenantDomain       Tenant Id.
+     * @return Updated CA Certificate Info.
+     * @throws CertificateValidationManagementException If an error occurs while updating the CA certificate.
+     */
+    CACertificateInfo updateCACertificate(String certificateId, String encodedCertificate, String tenantDomain)
+            throws CertificateValidationManagementException;
+
+    /**
+     * Delete CA Certificate.
+     *
+     * @param certificateId Certificate Id.
+     * @param tenantDomain  Tenant Id.
+     * @throws CertificateValidationManagementException If an error occurs while deleting the CA certificate.
+     */
+    void deleteCACertificate(String certificateId, String tenantDomain) throws CertificateValidationManagementException;
+}

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/persistence/CertificateValidationPersistenceManagerFactory.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/persistence/CertificateValidationPersistenceManagerFactory.java
@@ -49,17 +49,17 @@ public class CertificateValidationPersistenceManagerFactory {
 
         CertificateValidationPersistenceManager certificateValidationPersistenceManager;
         if (REGISTRY.equals(X509_CERTIFICATE_STORAGE_TYPE)) {
-            LOG.warn("Registry based KeyStore persistence manager was initialized");
+            LOG.warn("Registry based certificate validation persistence manager was initialized.");
             certificateValidationPersistenceManager = new RegistryCertificateValidationPersistenceManager();
         } else if (HYBRID.equals(X509_CERTIFICATE_STORAGE_TYPE)) {
-            LOG.info("Hybrid KeyStore persistence manager was initialized");
+            LOG.info("Hybrid certificate validation persistence manager was initialized.");
             certificateValidationPersistenceManager = new HybridCertificateValidationPersistenceManager();
         } else {
             certificateValidationPersistenceManager = new JDBCCertificateValidationPersistenceManager();
         }
 
         if (LOG.isDebugEnabled()) {
-            LOG.debug("KeyStore Persistence Manager initialized with the type: " +
+            LOG.debug("Certificate validation persistence manager was initialized with the type: " +
                     certificateValidationPersistenceManager.getClass());
         }
         return certificateValidationPersistenceManager;

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/persistence/CertificateValidationPersistenceManagerFactory.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/persistence/CertificateValidationPersistenceManagerFactory.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.x509Certificate.validation.persistence;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.x509Certificate.validation.persistence.impl.HybridCertificateValidationPersistenceManager;
+import org.wso2.carbon.identity.x509Certificate.validation.persistence.impl.JDBCCertificateValidationPersistenceManager;
+import org.wso2.carbon.identity.x509Certificate.validation.persistence.impl.RegistryCertificateValidationPersistenceManager;
+
+/**
+ * Factory class to get the CertificateValidationPersistenceManager based on the configuration.
+ */
+public class CertificateValidationPersistenceManagerFactory {
+
+    private static final Log LOG = LogFactory.getLog(CertificateValidationPersistenceManagerFactory.class);
+    private static final String X509_CERTIFICATE_STORAGE_TYPE =
+            IdentityUtil.getProperty("DataStorageType.CertificateValidation");
+    private static final String REGISTRY = "registry";
+    private static final String HYBRID = "hybrid";
+    private static final String DATABASE = "database";
+
+    private CertificateValidationPersistenceManagerFactory() {
+
+    }
+
+    public static CertificateValidationPersistenceManager getX509CertificatePersistenceManager() {
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("x509 certificate storage type is set to: " + X509_CERTIFICATE_STORAGE_TYPE);
+        }
+
+        CertificateValidationPersistenceManager certificateValidationPersistenceManager;
+        if (REGISTRY.equals(X509_CERTIFICATE_STORAGE_TYPE)) {
+            LOG.warn("Registry based KeyStore persistence manager was initialized");
+            certificateValidationPersistenceManager = new RegistryCertificateValidationPersistenceManager();
+        } else if (HYBRID.equals(X509_CERTIFICATE_STORAGE_TYPE)) {
+            LOG.info("Hybrid KeyStore persistence manager was initialized");
+            certificateValidationPersistenceManager = new HybridCertificateValidationPersistenceManager();
+        } else {
+            certificateValidationPersistenceManager = new JDBCCertificateValidationPersistenceManager();
+        }
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("KeyStore Persistence Manager initialized with the type: " +
+                    certificateValidationPersistenceManager.getClass());
+        }
+        return certificateValidationPersistenceManager;
+    }
+}

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/persistence/impl/HybridCertificateValidationPersistenceManager.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/persistence/impl/HybridCertificateValidationPersistenceManager.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.x509Certificate.validation.persistence.impl;
+
+import static org.wso2.carbon.identity.x509Certificate.validation.constant.error.ErrorMessage.ERROR_CERTIFICATE_DOES_NOT_EXIST;
+import java.security.cert.X509Certificate;
+import java.util.List;
+import org.wso2.carbon.identity.x509Certificate.validation.exception.CertificateValidationManagementException;
+import org.wso2.carbon.identity.x509Certificate.validation.model.CACertificate;
+import org.wso2.carbon.identity.x509Certificate.validation.model.CACertificateInfo;
+import org.wso2.carbon.identity.x509Certificate.validation.model.Validator;
+import org.wso2.carbon.identity.x509Certificate.validation.persistence.CertificateValidationPersistenceManager;
+
+/**
+ * HybridCertificateValidationPersistenceManager is a hybrid implementation of CertificateValidationPersistenceManager
+ * which uses both JDBC and Registry based persistence managers.
+ */
+public class HybridCertificateValidationPersistenceManager implements CertificateValidationPersistenceManager {
+
+    private final JDBCCertificateValidationPersistenceManager jdbcCertificateValidationPersistenceManager =
+            new JDBCCertificateValidationPersistenceManager();
+    private final RegistryCertificateValidationPersistenceManager registryCertificateValidationPersistenceManager =
+            new RegistryCertificateValidationPersistenceManager();
+
+    @Override
+    public void addValidators(List<Validator> validators, String tenatDomain)
+            throws CertificateValidationManagementException {
+
+        jdbcCertificateValidationPersistenceManager.addValidators(validators, tenatDomain);
+    }
+
+    @Override
+    public void addCACertificates(List<Validator> validators, List<X509Certificate> trustedCertificates,
+                                  String tenantDomain) throws CertificateValidationManagementException {
+
+        jdbcCertificateValidationPersistenceManager.addCACertificates(validators, trustedCertificates, tenantDomain);
+    }
+
+    @Override
+    public List<CACertificate> getCACertsByIssuer(String issuerDN, String tenantDomain)
+            throws CertificateValidationManagementException {
+
+        List<CACertificate> caCertificates =
+                jdbcCertificateValidationPersistenceManager.getCACertsByIssuer(issuerDN, tenantDomain);
+        caCertificates.addAll(
+                registryCertificateValidationPersistenceManager.getCACertsByIssuer(issuerDN, tenantDomain));
+        return caCertificates;
+    }
+
+    @Override
+    public List<Validator> getValidators(String tenantDomain) throws CertificateValidationManagementException {
+
+        return registryCertificateValidationPersistenceManager.getValidators(tenantDomain);
+    }
+
+    @Override
+    public Validator getValidator(String name, String tenantDomain) throws CertificateValidationManagementException {
+
+        return registryCertificateValidationPersistenceManager.getValidator(name, tenantDomain);
+    }
+
+    @Override
+    public Validator updateValidator(Validator validator, String tenantDomain)
+            throws CertificateValidationManagementException {
+
+        return registryCertificateValidationPersistenceManager.updateValidator(validator, tenantDomain);
+    }
+
+    @Override
+    public List<CACertificateInfo> getCACertificates(String tenantDomain)
+            throws CertificateValidationManagementException {
+
+        List<CACertificateInfo> caCertificates =
+                jdbcCertificateValidationPersistenceManager.getCACertificates(tenantDomain);
+        caCertificates.addAll(registryCertificateValidationPersistenceManager.getCACertificates(tenantDomain));
+        return caCertificates;
+    }
+
+    @Override
+    public CACertificateInfo addCACertificate(String encodedCertificate, String tenantDomain)
+            throws CertificateValidationManagementException {
+
+        return jdbcCertificateValidationPersistenceManager.addCACertificate(encodedCertificate, tenantDomain);
+    }
+
+    @Override
+    public CACertificateInfo getCACertificate(String certificateId, String tenantDomain)
+            throws CertificateValidationManagementException {
+
+        try {
+            return jdbcCertificateValidationPersistenceManager.getCACertificate(certificateId, tenantDomain);
+        } catch (CertificateValidationManagementException e) {
+            if (ERROR_CERTIFICATE_DOES_NOT_EXIST.getCode().equals(e.getErrorCode())) {
+                return registryCertificateValidationPersistenceManager.getCACertificate(certificateId, tenantDomain);
+            }
+            throw e;
+        }
+    }
+
+    @Override
+    public CACertificateInfo updateCACertificate(String certificateId, String encodedCertificate, String tenantDomain)
+            throws CertificateValidationManagementException {
+
+        try {
+            return jdbcCertificateValidationPersistenceManager.updateCACertificate(certificateId, encodedCertificate,
+                    tenantDomain);
+        } catch (CertificateValidationManagementException e) {
+            if (ERROR_CERTIFICATE_DOES_NOT_EXIST.getCode().equals(e.getErrorCode())) {
+                return registryCertificateValidationPersistenceManager.updateCACertificate(certificateId,
+                        encodedCertificate, tenantDomain);
+            } else {
+                throw e;
+            }
+        }
+    }
+
+    @Override
+    public void deleteCACertificate(String certificateId, String tenantDomain)
+            throws CertificateValidationManagementException {
+
+        try {
+            jdbcCertificateValidationPersistenceManager.deleteCACertificate(certificateId, tenantDomain);
+        } catch (CertificateValidationManagementException e) {
+            if (ERROR_CERTIFICATE_DOES_NOT_EXIST.getCode().equals(e.getErrorCode())) {
+                registryCertificateValidationPersistenceManager.deleteCACertificate(certificateId, tenantDomain);
+            } else {
+                throw e;
+            }
+        }
+    }
+}

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/persistence/impl/HybridCertificateValidationPersistenceManager.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/persistence/impl/HybridCertificateValidationPersistenceManager.java
@@ -19,6 +19,8 @@
 package org.wso2.carbon.identity.x509Certificate.validation.persistence.impl;
 
 import static org.wso2.carbon.identity.x509Certificate.validation.constant.error.ErrorMessage.ERROR_CERTIFICATE_DOES_NOT_EXIST;
+import static org.wso2.carbon.identity.x509Certificate.validation.constant.error.ErrorMessage.ERROR_INVALID_VALIDATOR_NAME;
+import static org.wso2.carbon.identity.x509Certificate.validation.constant.error.ErrorMessage.ERROR_NO_VALIDATORS_CONFIGURED_ON_TENANT;
 import java.security.cert.X509Certificate;
 import java.util.List;
 import org.wso2.carbon.identity.x509Certificate.validation.exception.CertificateValidationManagementException;
@@ -66,20 +68,45 @@ public class HybridCertificateValidationPersistenceManager implements Certificat
     @Override
     public List<Validator> getValidators(String tenantDomain) throws CertificateValidationManagementException {
 
-        return registryCertificateValidationPersistenceManager.getValidators(tenantDomain);
+
+        try {
+            return jdbcCertificateValidationPersistenceManager.getValidators(tenantDomain);
+        } catch (CertificateValidationManagementException e) {
+            if (ERROR_NO_VALIDATORS_CONFIGURED_ON_TENANT.getCode().equals(e.getErrorCode())) {
+                return registryCertificateValidationPersistenceManager.getValidators(tenantDomain);
+            } else {
+                throw e;
+            }
+        }
     }
 
     @Override
     public Validator getValidator(String name, String tenantDomain) throws CertificateValidationManagementException {
 
-        return registryCertificateValidationPersistenceManager.getValidator(name, tenantDomain);
+        try {
+            return jdbcCertificateValidationPersistenceManager.getValidator(name, tenantDomain);
+        } catch (CertificateValidationManagementException e) {
+            if (ERROR_INVALID_VALIDATOR_NAME.getCode().equals(e.getErrorCode())) {
+                return registryCertificateValidationPersistenceManager.getValidator(name, tenantDomain);
+            } else {
+                throw e;
+            }
+        }
     }
 
     @Override
     public Validator updateValidator(Validator validator, String tenantDomain)
             throws CertificateValidationManagementException {
 
-        return registryCertificateValidationPersistenceManager.updateValidator(validator, tenantDomain);
+        try {
+            return jdbcCertificateValidationPersistenceManager.updateValidator(validator, tenantDomain);
+        } catch (CertificateValidationManagementException e) {
+            if (ERROR_INVALID_VALIDATOR_NAME.getCode().equals(e.getErrorCode())) {
+                return registryCertificateValidationPersistenceManager.updateValidator(validator, tenantDomain);
+            } else {
+                throw e;
+            }
+        }
     }
 
     @Override

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/persistence/impl/HybridCertificateValidationPersistenceManager.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/persistence/impl/HybridCertificateValidationPersistenceManager.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.x509Certificate.validation.persistence.impl;
 
 import static org.wso2.carbon.identity.x509Certificate.validation.constant.error.ErrorMessage.ERROR_CERTIFICATE_DOES_NOT_EXIST;
 import static org.wso2.carbon.identity.x509Certificate.validation.constant.error.ErrorMessage.ERROR_INVALID_VALIDATOR_NAME;
+import static org.wso2.carbon.identity.x509Certificate.validation.constant.error.ErrorMessage.ERROR_NO_CA_CERTIFICATES_CONFIGURED_ON_TENANT;
 import static org.wso2.carbon.identity.x509Certificate.validation.constant.error.ErrorMessage.ERROR_NO_VALIDATORS_CONFIGURED_ON_TENANT;
 import java.security.cert.X509Certificate;
 import java.util.List;
@@ -44,14 +45,31 @@ public class HybridCertificateValidationPersistenceManager implements Certificat
     public void addValidators(List<Validator> validators, String tenatDomain)
             throws CertificateValidationManagementException {
 
-        jdbcCertificateValidationPersistenceManager.addValidators(validators, tenatDomain);
+        try {
+            registryCertificateValidationPersistenceManager.getValidators(tenatDomain);
+        } catch (CertificateValidationManagementException e) {
+            if (ERROR_NO_VALIDATORS_CONFIGURED_ON_TENANT.getCode().equals(e.getErrorCode())) {
+                jdbcCertificateValidationPersistenceManager.addValidators(validators, tenatDomain);
+            } else {
+                throw e;
+            }
+        }
     }
 
     @Override
     public void addCACertificates(List<Validator> validators, List<X509Certificate> trustedCertificates,
                                   String tenantDomain) throws CertificateValidationManagementException {
 
-        jdbcCertificateValidationPersistenceManager.addCACertificates(validators, trustedCertificates, tenantDomain);
+        try {
+            registryCertificateValidationPersistenceManager.getCACertificates(tenantDomain);
+        } catch (CertificateValidationManagementException e) {
+            if (ERROR_NO_CA_CERTIFICATES_CONFIGURED_ON_TENANT.getCode().equals(e.getErrorCode())) {
+                jdbcCertificateValidationPersistenceManager.addCACertificates(validators, trustedCertificates,
+                        tenantDomain);
+            } else {
+                throw e;
+            }
+        }
     }
 
     @Override

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/persistence/impl/JDBCCertificateValidationPersistenceManager.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/persistence/impl/JDBCCertificateValidationPersistenceManager.java
@@ -1,0 +1,1159 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.x509Certificate.validation.persistence.impl;
+
+import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_RESOURCES_DOES_NOT_EXISTS;
+import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_RESOURCE_ALREADY_EXISTS;
+import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_RESOURCE_DOES_NOT_EXISTS;
+import static org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationUtil.decodeCertificate;
+import static org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationUtil.encodeCertificate;
+import static org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationUtil.generateCertificateHash;
+import static org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationUtil.getAIALocations;
+import static org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationUtil.getCRLUrls;
+import static org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationUtil.getNormalizedName;
+import static org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationUtil.isSelfSignedCert;
+import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.CERTS;
+import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.CRL_VALIDATOR;
+import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.OCSP_VALIDATOR;
+import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.VALIDATOR_CONF_ENABLE;
+import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.VALIDATOR_CONF_FULL_CHAIN_VALIDATION;
+import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.VALIDATOR_CONF_NAME;
+import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.VALIDATOR_CONF_PRIORITY;
+import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.VALIDATOR_CONF_RETRY_COUNT;
+import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.VALIDATOR_RESOURCE_TYPE;
+import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.X509_CA_CERT_FILE;
+import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.X509_CA_CERT_RESOURCE_TYPE;
+import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.X509_CERT_PREFIX;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.certificate.management.constant.CertificateMgtErrors;
+import org.wso2.carbon.identity.certificate.management.exception.CertificateMgtException;
+import org.wso2.carbon.identity.certificate.management.model.Certificate;
+import org.wso2.carbon.identity.configuration.mgt.core.exception.ConfigurationManagementException;
+import org.wso2.carbon.identity.configuration.mgt.core.model.Attribute;
+import org.wso2.carbon.identity.configuration.mgt.core.model.Resource;
+import org.wso2.carbon.identity.configuration.mgt.core.model.ResourceFile;
+import org.wso2.carbon.identity.configuration.mgt.core.model.Resources;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationException;
+import org.wso2.carbon.identity.x509Certificate.validation.ModelSerializer;
+import org.wso2.carbon.identity.x509Certificate.validation.constant.error.ErrorMessage;
+import org.wso2.carbon.identity.x509Certificate.validation.exception.CertificateValidationManagementException;
+import org.wso2.carbon.identity.x509Certificate.validation.internal.CertValidationDataHolder;
+import org.wso2.carbon.identity.x509Certificate.validation.model.CACertificate;
+import org.wso2.carbon.identity.x509Certificate.validation.model.CACertificateInfo;
+import org.wso2.carbon.identity.x509Certificate.validation.model.CertObject;
+import org.wso2.carbon.identity.x509Certificate.validation.model.IssuerDNMap;
+import org.wso2.carbon.identity.x509Certificate.validation.model.Validator;
+import org.wso2.carbon.identity.x509Certificate.validation.persistence.CertificateValidationPersistenceManager;
+import org.wso2.carbon.identity.x509Certificate.validation.util.CertificateValidationManagementExceptionHandler;
+
+/**
+ * This implementation handles the keystore storage/persistence related logics in the Database.
+ */
+public class JDBCCertificateValidationPersistenceManager implements CertificateValidationPersistenceManager {
+
+    private static final Log LOG = LogFactory.getLog(JDBCCertificateValidationPersistenceManager.class);
+
+    @Override
+    public void addValidators(List<Validator> validators, String tenatDomain)
+            throws CertificateValidationManagementException {
+
+        try {
+            addValidatorsToConfigurationStore(validators);
+        } catch (CertificateValidationException e) {
+            throw CertificateValidationManagementExceptionHandler
+                    .handleServerException(ErrorMessage.ERROR_WHILE_ADDING_VALIDATORS, e, tenatDomain);
+        }
+    }
+
+    @Override
+    public void addCACertificates(List<Validator> validators, List<X509Certificate> trustedCertificates,
+                                  String tenantDomain) throws CertificateValidationManagementException {
+
+        try {
+            addCACertificateInConfigurationStore(validators, trustedCertificates, tenantDomain);
+        } catch (CertificateValidationException | JsonProcessingException | CertificateMgtException |
+                 CertificateException e) {
+            throw CertificateValidationManagementExceptionHandler
+                    .handleServerException(ErrorMessage.ERROR_WHILE_ADDING_CA_CERTIFICATES, e, tenantDomain);
+        }
+    }
+
+    @Override
+    public List<Validator> getValidators(String tenantDomain) throws CertificateValidationManagementException {
+
+        try {
+            return getValidatorsFromConfigStore(tenantDomain);
+        } catch (ConfigurationManagementException e) {
+            if (ERROR_CODE_RESOURCES_DOES_NOT_EXISTS.getCode().equals(e.getErrorCode())) {
+                return new ArrayList<>();
+            }
+            throw CertificateValidationManagementExceptionHandler
+                    .handleServerException(ErrorMessage.ERROR_WHILE_RETRIEVING_VALIDATORS, e);
+        }
+    }
+
+    @Override
+    public Validator getValidator(String name, String tenantDomain) throws CertificateValidationManagementException {
+
+        try {
+            name = name.toLowerCase();
+            Optional<Validator> validator = getValidatorFromConfigStoreByName(tenantDomain, name);
+
+            if (!validator.isPresent()) {
+                throw CertificateValidationManagementExceptionHandler
+                        .handleClientException(ErrorMessage.ERROR_INVALID_VALIDATOR_NAME, name, tenantDomain);
+            }
+            return validator.get();
+        } catch (CertificateValidationException e) {
+            throw CertificateValidationManagementExceptionHandler
+                    .handleServerException(ErrorMessage.ERROR_WHILE_RETRIEVING_VALIDATOR_BY_NAME, e);
+        }
+    }
+
+    @Override
+    public Validator updateValidator(Validator validator, String tenantDomain)
+            throws CertificateValidationManagementException {
+
+        try {
+            Optional<Validator> updatedValidator = updateValidatorInConfigStore(tenantDomain, validator);
+            if (!updatedValidator.isPresent()) {
+                throw CertificateValidationManagementExceptionHandler
+                        .handleClientException(ErrorMessage.ERROR_INVALID_VALIDATOR_NAME, validator.getName(),
+                                tenantDomain);
+            }
+            return updatedValidator.get();
+        } catch (CertificateValidationException e) {
+            throw CertificateValidationManagementExceptionHandler
+                    .handleServerException(ErrorMessage.ERROR_WHILE_UPDATING_VALIDATOR, e);
+        }
+    }
+
+    @Override
+    public List<CACertificateInfo> getCACertificates(String tenantDomain)
+            throws CertificateValidationManagementException {
+
+        try {
+            Optional<List<CACertificateInfo>> caCertificateInfoList =
+                    getCertificateListFromConfigurationStore(tenantDomain);
+            return caCertificateInfoList.orElseGet(ArrayList::new);
+        } catch (CertificateValidationException e) {
+            throw CertificateValidationManagementExceptionHandler
+                    .handleServerException(ErrorMessage.ERROR_WHILE_RETRIEVING_CA_CERTIFICATES, e);
+        }
+    }
+
+    @Override
+    public CACertificateInfo addCACertificate(String encodedCertificate, String tenantDomain)
+            throws CertificateValidationManagementException {
+
+        try {
+            X509Certificate caCertificate = decodeCertificate(encodedCertificate);
+            Optional<CertObject> certObject = addCertificateInConfigurationStore(tenantDomain, caCertificate);
+            if (!certObject.isPresent()) {
+                throw CertificateValidationManagementExceptionHandler
+                        .handleClientException(ErrorMessage.ERROR_NO_CA_CERTIFICATES_CONFIGURED_ON_TENANT,
+                                tenantDomain);
+            }
+            return getCACertificateInfo(caCertificate, certObject.get());
+        } catch (CertificateValidationException | CertificateException | CertificateMgtException | IOException |
+                 NoSuchAlgorithmException | ConfigurationManagementException e) {
+            throw CertificateValidationManagementExceptionHandler
+                    .handleServerException(ErrorMessage.ERROR_WHILE_ADDING_CA_CERTIFICATE, e);
+        }
+    }
+
+    @Override
+    public CACertificateInfo getCACertificate(String certificateId, String tenantDomain)
+            throws CertificateValidationManagementException {
+
+        try {
+            Optional<CACertificate> caCertificate =
+                    getCertificateFromConfigurationStoreByCertificateId(tenantDomain, certificateId);
+            if (!caCertificate.isPresent()) {
+                throw CertificateValidationManagementExceptionHandler
+                        .handleClientException(ErrorMessage.ERROR_CERTIFICATE_DOES_NOT_EXIST, certificateId,
+                                tenantDomain);
+            }
+            CACertificateInfo caCertificateInfo = new CACertificateInfo();
+            caCertificateInfo.setCertId(certificateId);
+            caCertificateInfo.setIssuerDN(getNormalizedName(caCertificate.get()
+                    .getX509Certificate().getIssuerDN().getName()));
+            caCertificateInfo.setSerialNumber(getNormalizedName(caCertificate.get().getX509Certificate()
+                    .getSerialNumber().toString()));
+            caCertificateInfo.setCrlUrls(caCertificate.get().getCrlUrl());
+            caCertificateInfo.setOcspUrls(caCertificate.get().getOcspUrl());
+            return caCertificateInfo;
+        } catch (CertificateValidationException e) {
+            throw CertificateValidationManagementExceptionHandler
+                    .handleServerException(ErrorMessage.ERROR_WHILE_RETRIEVING_CA_CERTIFICATE_BY_ID, e);
+        }
+    }
+
+    @Override
+    public CACertificateInfo updateCACertificate(String certificateId, String encodedCertificate, String tenantDomain)
+            throws CertificateValidationManagementException {
+
+        try {
+            X509Certificate certificate = decodeCertificate(encodedCertificate);
+            Optional<CertObject> certObject =
+                    updateCertificateInConfigurationStoreByCertificateId(certificateId, certificate, tenantDomain);
+            if (!certObject.isPresent()) {
+                throw CertificateValidationManagementExceptionHandler
+                        .handleClientException(ErrorMessage.ERROR_CERTIFICATE_DOES_NOT_EXIST, certificateId,
+                                tenantDomain);
+            }
+            X509Certificate updatedCertificate = updateCACertificateInCertificateManager(certificateId,
+                    certificate, tenantDomain);
+            CACertificateInfo caCertificateInfo = new CACertificateInfo();
+            caCertificateInfo.setCertId(certificateId);
+            caCertificateInfo.setIssuerDN(getNormalizedName(updatedCertificate.getIssuerDN().getName()));
+            caCertificateInfo.setSerialNumber(getNormalizedName(updatedCertificate.getSerialNumber().toString()));
+            caCertificateInfo.setCrlUrls(certObject.get().getCrlUrls());
+            caCertificateInfo.setOcspUrls(certObject.get().getOcspUrls());
+            return caCertificateInfo;
+        } catch (CertificateValidationException | CertificateException e) {
+            throw CertificateValidationManagementExceptionHandler
+                    .handleServerException(ErrorMessage.ERROR_WHILE_UPDATING_CA_CERTIFICATE, e);
+        }
+    }
+
+    @Override
+    public void deleteCACertificate(String certificateId, String tenantDomain)
+            throws CertificateValidationManagementException {
+
+        try {
+            Optional<CertObject> certObject =
+                    deleteCertificateInConfigurationStoreByCertificateId(certificateId, tenantDomain);
+            if (certObject.isPresent()) {
+                deleteCACertificateFromCertificateManager(certificateId, tenantDomain);
+            } else {
+                throw CertificateValidationManagementExceptionHandler
+                        .handleClientException(ErrorMessage.ERROR_CERTIFICATE_DOES_NOT_EXIST, certificateId,
+                                tenantDomain);
+            }
+        } catch (CertificateValidationException e) {
+            throw CertificateValidationManagementExceptionHandler
+                    .handleServerException(ErrorMessage.ERROR_WHILE_DELETING_CA_CERTIFICATE, e);
+        }
+    }
+
+    @Override
+    public List<CACertificate> getCACertsByIssuer(String issuerDN, String tenantDomain)
+            throws CertificateValidationManagementException {
+
+        try {
+            return getCACertsFromConfigStore(issuerDN);
+        } catch (CertificateValidationException | ConfigurationManagementException e) {
+            throw CertificateValidationManagementExceptionHandler
+                    .handleServerException(ErrorMessage.ERROR_WHILE_RETIREVING_CA_CERTIFICATE_BY_ISSUER, e, issuerDN,
+                            tenantDomain);
+        }
+    }
+
+    /**
+     * Get the certificate list from the configuration store.
+     *
+     * @param tenantDomain Tenant Domain.
+     * @return List of CACertificateInfo.
+     * @throws CertificateValidationException Error when getting certificate.
+     */
+    private static Optional<List<CACertificateInfo>> getCertificateListFromConfigurationStore(String tenantDomain)
+            throws CertificateValidationException {
+
+        try {
+            org.wso2.carbon.identity.configuration.mgt.core.model.Resource resource =
+                    CertValidationDataHolder.getInstance().getConfigurationManager()
+                            .getResourceByTenantId(IdentityTenantUtil.getTenantId(tenantDomain),
+                                    X509_CA_CERT_RESOURCE_TYPE, CERTS);
+            if (resource == null) {
+                return Optional.empty();
+            }
+            InputStream inputStream = getResourceFileInputStream(resource);
+            if (inputStream == null) {
+                return Optional.empty();
+            }
+            return Optional.of(parseCertificateList(inputStream, tenantDomain));
+        } catch (IOException | ConfigurationManagementException | CertificateException | CertificateMgtException e) {
+            throw new CertificateValidationException("Error while processing the resource", e);
+        }
+    }
+
+    private static InputStream getResourceFileInputStream
+            (org.wso2.carbon.identity.configuration.mgt.core.model.Resource resource)
+            throws ConfigurationManagementException {
+
+        List<ResourceFile> resourceFiles = resource.getFiles();
+        if (resourceFiles == null || resourceFiles.isEmpty()) {
+            LOG.debug("Resource files are empty for certificates in tenant: " + resource.getTenantDomain());
+            return null;
+        }
+        ResourceFile resourceFile = resourceFiles.get(0);
+        return resourceFile != null ? CertValidationDataHolder.getInstance().getConfigurationManager()
+                .getFileById(X509_CA_CERT_RESOURCE_TYPE, CERTS, resourceFile.getId()) : null;
+    }
+
+    private static List<CACertificateInfo> parseCertificateList(InputStream inputStream, String tenantDomain)
+            throws IOException, CertificateMgtException, CertificateException {
+
+        List<CACertificateInfo> certificateList = new ArrayList<>();
+        String fileContent = convertInputStreamToString(inputStream);
+        IssuerDNMap issuerDNMap = ModelSerializer.deserializeIssuerDNMap(fileContent);
+        for (Map.Entry<String, List<CertObject>> entry : issuerDNMap.getIssuerCertMap().entrySet()) {
+            for (CertObject certObject : entry.getValue()) {
+                certificateList.add(convertCertObjectToCACertificateInfo(certObject, tenantDomain));
+            }
+        }
+        return certificateList;
+    }
+
+    private static CACertificateInfo convertCertObjectToCACertificateInfo(CertObject certObject, String tenantDomain)
+            throws CertificateMgtException, CertificateException {
+
+        Certificate certificate = CertValidationDataHolder.getInstance()
+                .getCertificateManagementService()
+                .getCertificate(certObject.getCertId(), tenantDomain);
+        X509Certificate x509Certificate = decodeCertificate(certificate.getCertificateContent());
+
+        return getCACertificateInfo(x509Certificate, certObject);
+    }
+
+    /**
+     * Get the certificate from the configuration store by serial number.
+     *
+     * @param caCertificate X509Certificate.
+     * @param certObject    CertObject.
+     * @return CACertificateInfo.
+     */
+    private static CACertificateInfo getCACertificateInfo(X509Certificate caCertificate, CertObject certObject) {
+
+        CACertificateInfo caCertificateInfo = new CACertificateInfo();
+        caCertificateInfo.setCertId(certObject.getCertificatePersistedId());
+        caCertificateInfo.setIssuerDN(getNormalizedName(caCertificate.getIssuerDN().getName()));
+        caCertificateInfo.setSerialNumber(getNormalizedName(caCertificate.getSerialNumber().toString()));
+        caCertificateInfo.setCrlUrls(certObject.getCrlUrls());
+        caCertificateInfo.setOcspUrls(certObject.getOcspUrls());
+        return caCertificateInfo;
+    }
+
+    /**
+     * Update the CA certificate in the certificate manager.
+     *
+     * @param certificateId Certificate id
+     * @param certificate   X509Certificate
+     * @param tenantDomain  Tenant domain
+     * @return X509Certificate
+     * @throws CertificateValidationException Error when updating certificate
+     */
+    private static X509Certificate updateCACertificateInCertificateManager(String certificateId,
+                                                                           X509Certificate certificate,
+                                                                           String tenantDomain)
+            throws CertificateValidationException {
+
+        try {
+            CertValidationDataHolder.getInstance()
+                    .getCertificateManagementService()
+                    .getCertificate(certificateId, tenantDomain);
+            CertValidationDataHolder.getInstance()
+                    .getCertificateManagementService()
+                    .updateCertificateContent(certificateId, encodeCertificate(certificate), tenantDomain);
+            LOG.debug("Successfully updated certificate with the id: " + certificateId + " in certificate manager.");
+            return certificate;
+        } catch (CertificateMgtException e) {
+            if (CertificateMgtErrors.ERROR_CERTIFICATE_DOES_NOT_EXIST.getCode().equals(e.getErrorCode())) {
+                throw new CertificateValidationException
+                        ("Certificate with the id: " + certificateId + " does not exist.", e);
+            }
+            throw new CertificateValidationException("Error when updating certificate in certificate manager.", e);
+        } catch (CertificateException e) {
+            throw new CertificateValidationException("Error when encoding certificate.", e);
+        }
+    }
+
+    /**
+     * Get certificate from the configuration store by certificate id.
+     *
+     * @param tenantDomain  Tenant Domain
+     * @param certificateId Certificate Id
+     * @return CACertificate
+     * @throws CertificateValidationException Error when getting certificate
+     */
+    private static Optional<CACertificate> getCertificateFromConfigurationStoreByCertificateId(String tenantDomain,
+                                                                                               String certificateId)
+            throws CertificateValidationException {
+
+        try {
+            org.wso2.carbon.identity.configuration.mgt.core.model.Resource resource =
+                    CertValidationDataHolder.getInstance().getConfigurationManager().getResourceByTenantId
+                            (IdentityTenantUtil.getTenantId(tenantDomain), X509_CA_CERT_RESOURCE_TYPE, CERTS);
+            List<ResourceFile> resourceFiles = resource.getFiles();
+            if (resourceFiles == null || resourceFiles.isEmpty()) {
+                LOG.debug("Resource files are empty for certificates in tenant: " + resource.getTenantDomain());
+                return Optional.empty();
+            }
+
+            ResourceFile resourceFile = resourceFiles.get(0);
+            if (resourceFile == null) {
+                LOG.debug("Resource file is null for certificates in tenant: " + resource.getTenantDomain());
+                return Optional.empty();
+            }
+
+            InputStream inputStream = CertValidationDataHolder.getInstance()
+                    .getConfigurationManager()
+                    .getFileById(X509_CA_CERT_RESOURCE_TYPE, CERTS, resourceFile.getId());
+
+            if (inputStream == null) {
+                LOG.debug("InputStream is null for the file in resource.");
+                return Optional.empty();
+            }
+
+            String fileContent = convertInputStreamToString(inputStream);
+            IssuerDNMap issuerDNMap = ModelSerializer.deserializeIssuerDNMap(fileContent);
+
+            for (Map.Entry<String, List<CertObject>> entry : issuerDNMap.getIssuerCertMap().entrySet()) {
+                List<CertObject> certList = entry.getValue();
+                Optional<CertObject> certObject = certList.stream()
+                        .filter(cert -> cert.getCertId().equals(certificateId))
+                        .findFirst();
+
+                if (certObject.isPresent()) {
+                    return Optional.of(new CACertificate(certObject.get().getCrlUrls(),
+                            certObject.get().getOcspUrls(),
+                            getCACertificateFromCertificateManager(certificateId, tenantDomain)));
+                }
+            }
+            return Optional.empty();
+        } catch (ConfigurationManagementException e) {
+            throw new CertificateValidationException("Error while processing the resource", e);
+        } catch (IOException e) {
+            throw new CertificateValidationException("Error while reading the file content", e);
+        }
+    }
+
+    private static X509Certificate getCACertificateFromCertificateManager(String certificateId,
+                                                                          String tenantDomain)
+            throws CertificateValidationException {
+
+        try {
+            Certificate certificate = CertValidationDataHolder.getInstance()
+                    .getCertificateManagementService()
+                    .getCertificate(certificateId, tenantDomain);
+
+            return decodeCertificate(certificate.getCertificateContent());
+        } catch (CertificateMgtException e) {
+            LOG.debug("Error when getting certificate from certificate manager.", e);
+            if (CertificateMgtErrors.ERROR_CERTIFICATE_DOES_NOT_EXIST.getCode().equals(e.getErrorCode())) {
+                throw new CertificateValidationException
+                        ("Certificate with the id: " + certificateId + " does not exist.", e);
+            }
+            throw new CertificateValidationException("Error when getting certificate from certificate manager.", e);
+        } catch (CertificateException e) {
+            throw new CertificateValidationException("Error when decoding certificate.", e);
+        }
+    }
+
+    /**
+     * Converts a Resource object into a Validator object.
+     *
+     * @param resource The resource object to convert.
+     * @return A Validator object populated with resource attributes.
+     */
+    private static Validator resourceToValidatorObject(
+            org.wso2.carbon.identity.configuration.mgt.core.model.Resource resource) {
+
+        Validator validator = new Validator();
+
+        // Extract attributes from the resource.
+        List<Attribute> attributes = resource.getAttributes();
+        validator.setDisplayName(resource.getResourceName());
+        if (attributes != null) {
+            for (Attribute attribute : attributes) {
+                String key = attribute.getKey();
+                String value = attribute.getValue();
+
+                switch (key) {
+                    case VALIDATOR_CONF_NAME:
+                        validator.setName(value);
+                        break;
+                    case VALIDATOR_CONF_ENABLE:
+                        validator.setEnabled(Boolean.parseBoolean(value));
+                        break;
+                    case VALIDATOR_CONF_PRIORITY:
+                        validator.setPriority(Integer.parseInt(value));
+                        break;
+                    case VALIDATOR_CONF_FULL_CHAIN_VALIDATION:
+                        validator.setFullChainValidationEnabled(Boolean.parseBoolean(value));
+                        break;
+                    case VALIDATOR_CONF_RETRY_COUNT:
+                        validator.setRetryCount(Integer.parseInt(value));
+                        break;
+                    default:
+                        // Ignore unknown attributes.
+                        break;
+                }
+            }
+        }
+        return validator;
+    }
+
+    /**
+     * Update validator in the configuration store.
+     *
+     * @param tenantDomain Tenant Domain.
+     * @param validator    Validator.
+     * @return Validator object.
+     * @throws CertificateValidationException Error when updating validator.
+     */
+    private static Optional<Validator> updateValidatorInConfigStore(String tenantDomain, Validator validator)
+            throws CertificateValidationException {
+
+        try {
+            org.wso2.carbon.identity.configuration.mgt.core.model.Resource resource =
+                    CertValidationDataHolder.getInstance().getConfigurationManager()
+                            .getResourceByTenantId(IdentityTenantUtil.getTenantId(tenantDomain),
+                                    VALIDATOR_RESOURCE_TYPE, validator.getDisplayName());
+            if (resource == null) {
+                return Optional.empty();
+            }
+            createAttributeList(validator, resource);
+            org.wso2.carbon.identity.configuration.mgt.core.model.Resource updatedResource =
+                    CertValidationDataHolder.getInstance().getConfigurationManager()
+                            .replaceResource(VALIDATOR_RESOURCE_TYPE, resource);
+            return Optional.of(resourceToValidatorObject(updatedResource));
+        } catch (ConfigurationManagementException e) {
+            throw new CertificateValidationException("Error while fetching validator configurations.", e);
+        }
+    }
+
+    /**
+     * Get validator from the configuration store by name.
+     *
+     * @param tenantDomain Tenant Domain.
+     * @param name         Validator name.
+     * @return Validator object.
+     * @throws CertificateValidationException Error when getting validator.
+     */
+    private static Optional<Validator> getValidatorFromConfigStoreByName(String tenantDomain, String name)
+            throws CertificateValidationException {
+
+        try {
+            org.wso2.carbon.identity.configuration.mgt.core.model.Resource resource =
+                    CertValidationDataHolder.getInstance().getConfigurationManager()
+                            .getResourceByTenantId(IdentityTenantUtil.getTenantId(tenantDomain),
+                                    VALIDATOR_RESOURCE_TYPE, name);
+            if (resource == null) {
+                return Optional.empty();
+            }
+            return Optional.of(resourceToValidatorObject(resource));
+        } catch (ConfigurationManagementException e) {
+            throw new CertificateValidationException("Error while fetching validator configurations.", e);
+        }
+    }
+
+    /**
+     * Get validators from the configuration store.
+     *
+     * @param tenantDomain Tenant Domain.
+     * @return List of Validator.
+     * @throws ConfigurationManagementException Error when getting resource.
+     */
+    private static List<Validator> getValidatorsFromConfigStore(String tenantDomain)
+            throws ConfigurationManagementException {
+
+        List<Validator> validators = new ArrayList<>();
+        Resources resources = CertValidationDataHolder.getInstance().getConfigurationManager()
+                .getResourcesByType(IdentityTenantUtil.getTenantId(tenantDomain), VALIDATOR_RESOURCE_TYPE);
+        resources.getResources().forEach(resource -> validators.add(resourceToValidatorObject(resource)));
+        return validators;
+    }
+
+    private static List<String> getValidationUrls(X509Certificate certificate, String tenantDomain,
+                                                  String validatorType)
+            throws ConfigurationManagementException, CertificateValidationException {
+
+        List<String> urls = new ArrayList<>();
+        if (!isSelfSignedCert(certificate)) {
+            for (Validator validator : getValidatorsFromConfigStore(tenantDomain)) {
+                if (validator.isEnabled() && validatorType.equals(validator.getDisplayName())) {
+                    urls = OCSP_VALIDATOR.equals(validatorType) ? getAIALocations(certificate) :
+                            getCRLUrls(certificate);
+                }
+            }
+        }
+        return urls;
+    }
+
+    /**
+     * update the certificate in the configuration store by certificate id.
+     *
+     * @param certificateId certificate id.
+     * @param certificate   X509Certificate.
+     * @param tenantDomain  tenant domain.
+     * @return CertObject.
+     * @throws CertificateValidationException Error when updating certificate.
+     */
+    private static Optional<CertObject> updateCertificateInConfigurationStoreByCertificateId(String certificateId,
+                                                                                             X509Certificate certificate,
+                                                                                             String tenantDomain)
+            throws CertificateValidationException {
+
+        try {
+            org.wso2.carbon.identity.configuration.mgt.core.model.Resource resource = CertValidationDataHolder
+                    .getInstance().getConfigurationManager()
+                    .getResourceByTenantId(IdentityTenantUtil.getTenantId(tenantDomain),
+                            X509_CA_CERT_RESOURCE_TYPE, CERTS);
+            InputStream inputStream = getResourceFileInputStream(resource);
+            if (inputStream == null) {
+                return Optional.empty();
+            }
+
+            IssuerDNMap issuerDNMap = ModelSerializer.deserializeIssuerDNMap(convertInputStreamToString(inputStream));
+            String issuerDN = getNormalizedName(certificate.getIssuerDN().getName());
+            String serialNumber = getNormalizedName(certificate.getSerialNumber().toString());
+
+            List<String> ocspUrls = getValidationUrls(certificate, tenantDomain, OCSP_VALIDATOR);
+            List<String> crlUrls = getValidationUrls(certificate, tenantDomain, CRL_VALIDATOR);
+
+            boolean certExistsInMap = false;
+            String previousIssuer = null;
+
+            // Check if certificateId exists anywhere in the issuer map
+            for (Map.Entry<String, List<CertObject>> entry : issuerDNMap.getIssuerCertMap().entrySet()) {
+                for (CertObject cert : entry.getValue()) {
+                    if (cert.getCertId().equals(certificateId)) {
+                        certExistsInMap = true;
+                        previousIssuer = entry.getKey();
+                        break;
+                    }
+                }
+                if (certExistsInMap) {
+                    break;
+                }
+            }
+
+            // If the certId is not found in the entire map, throw an error
+            if (!certExistsInMap) {
+                throw new CertificateValidationException("Certificate with certId: " + certificateId +
+                        " does not exist in the issuer map.");
+            }
+
+            // Get the list of certificates for the given issuer
+            List<CertObject> certList = issuerDNMap.getIssuerCertMap().getOrDefault(issuerDN, new ArrayList<>());
+            int certIndex = -1;
+
+            // Check if the certId exists within this issuer
+            for (int i = 0; i < certList.size(); i++) {
+                if (certList.get(i).getCertId().equals(certificateId)) {
+                    certIndex = i;
+                    break;
+                }
+            }
+
+            // Create an updated CertObject
+            CertObject updatedCertObject = new CertObject();
+            updatedCertObject.setCertId(generateCertificateHash(certificate));
+            updatedCertObject.setCertificatePersistedId(certificateId);
+            updatedCertObject.setSerialNumber(serialNumber);
+            updatedCertObject.setCrlUrls(crlUrls);
+            updatedCertObject.setOcspUrls(ocspUrls);
+
+            if (certIndex != -1) {
+                // Case 2: Cert ID exists under the same issuer → Update the certificate
+                certList.set(certIndex, updatedCertObject);
+            } else {
+                // Case 3: Cert ID does not exist under this issuer → Add as a new cert
+                certList.add(updatedCertObject);
+
+                // Case 4: Remove the cert from the previous issuer (if different)
+                if (!issuerDN.equals(previousIssuer) && previousIssuer != null) {
+                    List<CertObject> previousCertList = issuerDNMap.getIssuerCertMap().get(previousIssuer);
+                    previousCertList.removeIf(cert -> cert.getCertId().equals(certificateId));
+
+                    // If no certificates remain for the old issuer, remove the issuer entry
+                    if (previousCertList.isEmpty()) {
+                        issuerDNMap.getIssuerCertMap().remove(previousIssuer);
+                    } else {
+                        // Otherwise, just update the cert list without removing the issuer
+                        issuerDNMap.getIssuerCertMap().put(previousIssuer, previousCertList);
+                    }
+                }
+            }
+
+            // Update the issuer map with the modified cert list
+            issuerDNMap.getIssuerCertMap().put(issuerDN, certList);
+
+            saveUpdatedResource(resource, issuerDNMap);
+            return Optional.of(updatedCertObject);
+        } catch (ConfigurationManagementException | IOException | NoSuchAlgorithmException e) {
+            throw new CertificateValidationException("Error while processing the resource", e);
+        }
+    }
+
+    /**
+     * Delete the ca certificate from the certificate manager.
+     *
+     * @param certificateId Certificate id
+     * @param tenantDomain  Tenant domain
+     * @throws CertificateValidationException Error when deleting certificate
+     */
+    private static void deleteCACertificateFromCertificateManager(String certificateId,
+                                                                  String tenantDomain)
+            throws CertificateValidationException {
+
+        try {
+            CertValidationDataHolder.getInstance()
+                    .getCertificateManagementService()
+                    .deleteCertificate(certificateId, tenantDomain);
+        } catch (CertificateMgtException e) {
+            if (CertificateMgtErrors.ERROR_CERTIFICATE_DOES_NOT_EXIST.getCode().equals(e.getErrorCode())) {
+                throw new CertificateValidationException
+                        ("Certificate with the id: " + certificateId + " does not exist.", e);
+            }
+            throw new CertificateValidationException("Error when getting certificate from certificate manager.", e);
+        }
+    }
+
+    /**
+     * Delete a certificate in the configuration store by certificate id.
+     *
+     * @param certificateId Certificate Id
+     * @param tenantDomain  Tenant Domain
+     * @return CertObject
+     * @throws CertificateValidationException Error when deleting certificate
+     */
+    private static Optional<CertObject> deleteCertificateInConfigurationStoreByCertificateId(String certificateId,
+                                                                                             String tenantDomain)
+            throws CertificateValidationException {
+
+        try {
+            org.wso2.carbon.identity.configuration.mgt.core.model.Resource resource =
+                    CertValidationDataHolder.getInstance().getConfigurationManager()
+                            .getResourceByTenantId(IdentityTenantUtil.getTenantId(tenantDomain),
+                                    X509_CA_CERT_RESOURCE_TYPE, CERTS);
+            InputStream inputStream = getResourceFileInputStream(resource);
+            if (inputStream == null) {
+                return Optional.empty();
+            }
+
+            IssuerDNMap issuerDNMap = ModelSerializer.deserializeIssuerDNMap(convertInputStreamToString(inputStream));
+
+            for (Map.Entry<String, List<CertObject>> entry : issuerDNMap.getIssuerCertMap().entrySet()) {
+                List<CertObject> certList = entry.getValue();
+                if (certList.removeIf(cert -> cert.getCertId().equals(certificateId))) {
+                    if (certList.isEmpty()) {
+                        issuerDNMap.getIssuerCertMap().remove(entry.getKey());
+                    }
+                    saveUpdatedResource(resource, issuerDNMap);
+                    return Optional.of(new CertObject());
+                }
+            }
+            return Optional.empty();
+        } catch (IOException | ConfigurationManagementException e) {
+            throw new CertificateValidationException("Error while processing the resource", e);
+        }
+    }
+
+    private static Optional<CertObject> addCertificateInConfigurationStore(String tenantDomain,
+                                                                           X509Certificate certificate)
+            throws CertificateValidationException, CertificateException, CertificateMgtException,
+            IOException, NoSuchAlgorithmException, ConfigurationManagementException {
+
+        try {
+            Resource resource = getResource(tenantDomain);
+            if (resource == null) {
+                return Optional.empty();
+            }
+
+            IssuerDNMap issuerDNMap = getIssuerDNMap(resource);
+            String issuerDN = getNormalizedName(certificate.getIssuerDN().getName());
+            String serialNumber = getNormalizedName(certificate.getSerialNumber().toString());
+
+            List<String> ocspUrls = getValidationUrls(certificate, tenantDomain, OCSP_VALIDATOR);
+            List<String> crlUrls = getValidationUrls(certificate, tenantDomain, CRL_VALIDATOR);
+
+            String certId = addCertificateToManagementService(certificate, tenantDomain);
+            CertObject certObject = createCertObject(certificate, certId, serialNumber, ocspUrls, crlUrls);
+
+            addCertObjectToIssuerDNMap(issuerDNMap, issuerDN, certObject, serialNumber);
+
+            saveUpdatedResource(resource, issuerDNMap);
+            return Optional.of(certObject);
+        } catch (IOException | CertificateException | CertificateMgtException | NoSuchAlgorithmException e) {
+            throw new CertificateValidationException("Error while processing the resource", e);
+        } catch (ConfigurationManagementException e) {
+            if (ERROR_CODE_RESOURCE_DOES_NOT_EXISTS.getCode().equals(e.getErrorCode())) {
+                return handleResourceNotExists(certificate, tenantDomain);
+            } else {
+                throw new CertificateValidationException("Error while retrieving the resource", e);
+            }
+        }
+    }
+
+    private static Resource getResource(String tenantDomain) throws ConfigurationManagementException {
+
+        return CertValidationDataHolder.getInstance().getConfigurationManager()
+                .getResourceByTenantId(IdentityTenantUtil.getTenantId(tenantDomain), X509_CA_CERT_RESOURCE_TYPE, CERTS);
+    }
+
+    private static IssuerDNMap getIssuerDNMap(Resource resource) throws IOException, ConfigurationManagementException {
+
+        InputStream inputStream = getResourceFileInputStream(resource);
+        if (inputStream == null) {
+            return new IssuerDNMap();
+        }
+        return ModelSerializer.deserializeIssuerDNMap(convertInputStreamToString(inputStream));
+    }
+
+    private static String addCertificateToManagementService(X509Certificate certificate, String tenantDomain)
+            throws CertificateMgtException, CertificateException {
+
+        Certificate newCert = new Certificate.Builder()
+                .name(X509_CERT_PREFIX + UUID.randomUUID())
+                .certificateContent(encodeCertificate(certificate))
+                .build();
+        return CertValidationDataHolder.getInstance().getCertificateManagementService()
+                .addCertificate(newCert, tenantDomain);
+    }
+
+    private static CertObject createCertObject(X509Certificate certificate, String certId, String serialNumber,
+                                               List<String> ocspUrls, List<String> crlUrls)
+            throws NoSuchAlgorithmException {
+        CertObject certObject = new CertObject();
+        certObject.setCertId(generateCertificateHash(certificate));
+        certObject.setCertificatePersistedId(certId);
+        certObject.setSerialNumber(serialNumber);
+        certObject.setCrlUrls(crlUrls);
+        certObject.setOcspUrls(ocspUrls);
+        return certObject;
+    }
+
+    private static void addCertObjectToIssuerDNMap(IssuerDNMap issuerDNMap, String issuerDN, CertObject certObject,
+                                                   String serialNumber) throws CertificateValidationException {
+        List<CertObject> certList = issuerDNMap.getIssuerCertMap().computeIfAbsent(issuerDN, k -> new ArrayList<>());
+        boolean serialExists = certList.stream()
+                .anyMatch(cert -> getNormalizedName(cert.getSerialNumber()).equals(serialNumber));
+
+        if (serialExists) {
+            throw new CertificateValidationException("Certificate with the serial number: " + serialNumber +
+                    " already exists for the issuerDN: " + issuerDN);
+        } else {
+            LOG.debug("Adding new certificate with serial number: " + serialNumber + " for issuerDN: " + issuerDN);
+            certList.add(certObject);
+        }
+    }
+
+    private static Optional<CertObject> handleResourceNotExists(X509Certificate certificate, String tenantDomain)
+            throws CertificateValidationException, CertificateException, CertificateMgtException,
+            NoSuchAlgorithmException, ConfigurationManagementException, IOException {
+
+        IssuerDNMap issuerDNMap = new IssuerDNMap();
+        String issuerDN = getNormalizedName(certificate.getIssuerDN().getName());
+        String serialNumber = getNormalizedName(certificate.getSerialNumber().toString());
+
+        List<String> ocspUrls = getValidationUrls(certificate, tenantDomain, OCSP_VALIDATOR);
+        List<String> crlUrls = getValidationUrls(certificate, tenantDomain, CRL_VALIDATOR);
+
+        String certId = addCertificateToManagementService(certificate, tenantDomain);
+        CertObject certObject = createCertObject(certificate, certId, serialNumber, ocspUrls, crlUrls);
+
+        List<CertObject> certObjectList = new ArrayList<>();
+        certObjectList.add(certObject);
+        issuerDNMap.getIssuerCertMap().put(issuerDN, certObjectList);
+
+        saveNewResource(issuerDNMap);
+        return Optional.of(certObject);
+    }
+
+    private static void saveNewResource(IssuerDNMap issuerDNMap) throws IOException, CertificateValidationException {
+
+        String serializedContent = ModelSerializer.serializeIssuerDNMap(issuerDNMap);
+        InputStream inputStream = new ByteArrayInputStream(serializedContent.getBytes(StandardCharsets.UTF_8));
+
+        ResourceFile resourceFile = new ResourceFile();
+        resourceFile.setName(X509_CA_CERT_FILE);
+        resourceFile.setInputStream(inputStream);
+
+        Resource resource = new Resource(CERTS, X509_CA_CERT_RESOURCE_TYPE);
+        resource.setHasFile(true);
+        resource.setFiles(new ArrayList<>());
+        resource.getFiles().add(resourceFile);
+
+        addResource(resource);
+    }
+
+    private static void saveUpdatedResource(org.wso2.carbon.identity.configuration.mgt.core.model.Resource resource,
+                                            IssuerDNMap issuerDNMap)
+            throws IOException, ConfigurationManagementException {
+
+        String serializedContent = ModelSerializer.serializeIssuerDNMap(issuerDNMap);
+        InputStream inputStreamUpdated = new ByteArrayInputStream(serializedContent.getBytes(StandardCharsets.UTF_8));
+
+        ResourceFile resourceFileUpdated = new ResourceFile();
+        resourceFileUpdated.setName(X509_CA_CERT_FILE);
+        resourceFileUpdated.setInputStream(inputStreamUpdated);
+        resource.getFiles().set(0, resourceFileUpdated);
+
+        CertValidationDataHolder.getInstance().getConfigurationManager()
+                .replaceResource(X509_CA_CERT_RESOURCE_TYPE, resource);
+    }
+
+    private static void addValidatorsToConfigurationStore(List<Validator> defaultValidatorConfig)
+            throws CertificateValidationException {
+        for (Validator validator : defaultValidatorConfig) {
+            String displayName = validator.getDisplayName();
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Adding the configurations for validator: " + displayName);
+            }
+
+            org.wso2.carbon.identity.configuration.mgt.core.model.Resource validatorResource =
+                    buildResourceFromValidator(validator, getNormalizedName(displayName));
+            addResource(validatorResource);
+        }
+    }
+
+    /**
+     * Builds a Resource object from the Validator configuration.
+     *
+     * @param validator    Validator configuration object.
+     * @param resourceName Resource name.
+     * @return A new Resource object with the validator's properties.
+     */
+    private static org.wso2.carbon.identity.configuration.mgt.core.model.Resource buildResourceFromValidator(
+            Validator validator, String resourceName) {
+
+        org.wso2.carbon.identity.configuration.mgt.core.model.Resource resource =
+                new org.wso2.carbon.identity.configuration.mgt.core.model.Resource(resourceName,
+                        VALIDATOR_RESOURCE_TYPE);
+        resource.setHasAttribute(true);
+        createAttributeList(validator, resource);
+
+        return resource;
+    }
+
+    private static void createAttributeList(Validator validator,
+                                            org.wso2.carbon.identity.configuration.mgt.core.model.Resource resource) {
+
+        List<Attribute> attributes = new ArrayList<>();
+        attributes.add(new Attribute(VALIDATOR_CONF_NAME, validator.getName()));
+        attributes.add(new Attribute(VALIDATOR_CONF_ENABLE,
+                Boolean.toString(validator.isEnabled())));
+        attributes.add(new Attribute(VALIDATOR_CONF_PRIORITY,
+                Integer.toString(validator.getPriority())));
+        attributes.add(new Attribute(VALIDATOR_CONF_FULL_CHAIN_VALIDATION,
+                Boolean.toString(validator.isFullChainValidationEnabled())));
+        attributes.add(new Attribute(VALIDATOR_CONF_RETRY_COUNT,
+                Integer.toString(validator.getRetryCount())));
+        resource.setAttributes(attributes);
+    }
+
+    private static void addCACertificateInConfigurationStore(List<Validator> validators,
+                                                             List<X509Certificate> trustedCertificates,
+                                                             String tenantDomain) throws
+            CertificateValidationException, CertificateException, CertificateMgtException, JsonProcessingException {
+
+        Map<String, List<CertObject>> issuerDNMap = new HashMap<>();
+        for (X509Certificate certificate : trustedCertificates) {
+            String issuerDN = getNormalizedName(certificate.getIssuerDN().getName());
+            String serialNumber = getNormalizedName(certificate.getSerialNumber().toString());
+
+            // Check if the serial number already exists for the given IssuerDN
+            List<CertObject> existingCertObjects = issuerDNMap.computeIfAbsent(issuerDN, k -> new ArrayList<>());
+            boolean isSerialNumberAlreadyAdded = existingCertObjects.stream()
+                    .anyMatch(certObject -> certObject.getSerialNumber().equals(serialNumber));
+
+            if (isSerialNumberAlreadyAdded) {
+                LOG.warn("Certificate with serial number " + serialNumber + " already exists for IssuerDN " +
+                        issuerDN);
+                continue;
+            }
+
+            List<String> ocspUrls = new ArrayList<>();
+            List<String> crlUrls = new ArrayList<>();
+            boolean isSelfSignedCert = isSelfSignedCert(certificate);
+
+            for (Validator validator : validators) {
+                if (validator.isEnabled()) {
+                    if (OCSP_VALIDATOR.equals(validator.getDisplayName()) &&
+                            !isSelfSignedCert) {
+                        ocspUrls = getAIALocations(certificate);
+                    } else if (CRL_VALIDATOR.equals(validator.getDisplayName()) &&
+                            !isSelfSignedCert) {
+                        crlUrls = getCRLUrls(certificate);
+                    }
+                }
+            }
+
+            Certificate cert = new Certificate.Builder()
+                    .name(X509_CERT_PREFIX + UUID.randomUUID())
+                    .certificateContent(encodeCertificate(certificate))
+                    .build();
+            String certId = CertValidationDataHolder.getInstance().getCertificateManagementService()
+                    .addCertificate(cert, tenantDomain);
+
+            CertObject certObject = new CertObject();
+            certObject.setCertId(certId);
+            certObject.setSerialNumber(serialNumber);
+            certObject.setCrlUrls(crlUrls);
+            certObject.setOcspUrls(ocspUrls);
+
+            existingCertObjects.add(certObject);
+        }
+
+        IssuerDNMap combinedIssuerDNMap = new IssuerDNMap();
+        for (Map.Entry<String, List<CertObject>> entry : issuerDNMap.entrySet()) {
+            String issuerDN = entry.getKey();
+            List<CertObject> certObjects = entry.getValue();
+            combinedIssuerDNMap.getIssuerCertMap().put(issuerDN, certObjects);
+        }
+
+        String serializedContent = ModelSerializer.serializeIssuerDNMap(combinedIssuerDNMap);
+
+        InputStream inputStream = new ByteArrayInputStream(serializedContent.getBytes(StandardCharsets.UTF_8));
+
+        ResourceFile resourceFile = new ResourceFile();
+        resourceFile.setName(X509_CA_CERT_FILE);
+        resourceFile.setInputStream(inputStream);
+
+        org.wso2.carbon.identity.configuration.mgt.core.model.Resource resource =
+                new org.wso2.carbon.identity.configuration.mgt.core.model.Resource(CERTS, X509_CA_CERT_RESOURCE_TYPE);
+        resource.setHasFile(true);
+        resource.setFiles(new ArrayList<>());
+        resource.getFiles().add(resourceFile);
+
+        // Add the resource to the configuration store
+        addResource(resource);
+    }
+
+    private static List<CACertificate> getCACertsFromConfigStore(String issuerDN)
+            throws CertificateValidationException, ConfigurationManagementException {
+
+        org.wso2.carbon.identity.configuration.mgt.core.model.Resource resource = CertValidationDataHolder.getInstance()
+                .getConfigurationManager()
+                .getResource(X509_CA_CERT_RESOURCE_TYPE, CERTS);
+
+        List<CACertificate> certificateList = new ArrayList<>();
+
+        try {
+            List<ResourceFile> resourceFiles = resource.getFiles();
+            if (resourceFiles == null || resourceFiles.isEmpty()) {
+                LOG.warn("Resource files are empty for certificates in tenant: " + resource.getTenantDomain());
+                return certificateList;
+            }
+
+            ResourceFile resourceFile = resourceFiles.get(0);
+            if (resourceFile == null) {
+                LOG.warn("Resource file is null for certificates in tenant: " + resource.getTenantDomain());
+                return certificateList;
+            }
+
+            InputStream inputStream = CertValidationDataHolder.getInstance()
+                    .getConfigurationManager()
+                    .getFileById(X509_CA_CERT_RESOURCE_TYPE, CERTS, resourceFile.getId());
+
+            if (inputStream == null) {
+                LOG.warn("InputStream is null for the file in resource for IssuerDN: " + issuerDN);
+                return certificateList;
+            }
+
+            String fileContent = convertInputStreamToString(inputStream);
+            IssuerDNMap issuerDNMap = ModelSerializer.deserializeIssuerDNMap(fileContent);
+
+            List<CertObject> certObjects = issuerDNMap.getIssuerCertMap().get(issuerDN);
+            if (certObjects != null) {
+                for (CertObject certObject : certObjects) {
+                    // Extract details from the CertObject
+                    String certId = certObject.getCertId();
+                    List<String> crlUrls = certObject.getCrlUrls();
+                    List<String> ocspUrls = certObject.getOcspUrls();
+
+                    Certificate certificate = CertValidationDataHolder.getInstance()
+                            .getCertificateManagementService()
+                            .getCertificate(certId, PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                                    .getTenantDomain());
+
+                    X509Certificate x509Certificate = decodeCertificate(certificate.getCertificateContent());
+
+                    CACertificate caCertificate = new CACertificate(crlUrls, ocspUrls, x509Certificate);
+                    certificateList.add(caCertificate);
+                }
+            }
+        } catch (IOException e) {
+            LOG.error("Error while reading the file content for IssuerDN: " + issuerDN, e);
+            throw new CertificateValidationException("Error while reading the file content for IssuerDN: " +
+                    issuerDN, e);
+        } catch (Exception e) {
+            LOG.error("Error while processing the resource for IssuerDN: " + issuerDN, e);
+            throw new CertificateValidationException("Error while processing the resource for IssuerDN: " +
+                    issuerDN, e);
+        }
+
+        return certificateList;
+    }
+
+    /**
+     * Adds specified resource to the configuration management system.
+     *
+     * @param resource The resource object to add.
+     * @throws CertificateValidationException If an error occurs while adding the resource.
+     */
+    private static void addResource(
+            org.wso2.carbon.identity.configuration.mgt.core.model.Resource resource)
+            throws CertificateValidationException {
+
+        try {
+            CertValidationDataHolder.getInstance().getConfigurationManager()
+                    .addResource(resource.getResourceType(), resource);
+        } catch (ConfigurationManagementException e) {
+            if (ERROR_CODE_RESOURCE_ALREADY_EXISTS.getCode().equals(e.getErrorCode())) {
+                LOG.debug("Resource already exists in the tenant config store.");
+            } else {
+                throw new CertificateValidationException("Error while adding validator configurations.", e);
+            }
+        }
+    }
+
+    private static String convertInputStreamToString(InputStream inputStream) throws IOException {
+        StringBuilder stringBuilder = new StringBuilder();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                stringBuilder.append(line);
+            }
+        }
+        return stringBuilder.toString();
+    }
+}

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/persistence/impl/RegistryCertificateValidationPersistenceManager.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/persistence/impl/RegistryCertificateValidationPersistenceManager.java
@@ -1,0 +1,644 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.x509Certificate.validation.persistence.impl;
+
+import static org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationUtil.decodeCertificate;
+import static org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationUtil.encodeCertificate;
+import static org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationUtil.generateCertificateHash;
+import static org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationUtil.getAIALocations;
+import static org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationUtil.getCACertRegFullPath;
+import static org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationUtil.getCRLUrls;
+import static org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationUtil.getNormalizedName;
+import static org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationUtil.isSelfSignedCert;
+import static org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationUtil.resourceToValidatorObject;
+import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.CA_CERT_REG_CRL;
+import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.CA_CERT_REG_CRL_OCSP_SEPERATOR;
+import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.CA_CERT_REG_OCSP;
+import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.CA_CERT_REG_PATH;
+import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.CERTFICATE_ID;
+import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.CRL_VALIDATOR;
+import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.OCSP_VALIDATOR;
+import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.VALIDATOR_CONF_ENABLE;
+import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.VALIDATOR_CONF_FULL_CHAIN_VALIDATION;
+import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.VALIDATOR_CONF_NAME;
+import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.VALIDATOR_CONF_PRIORITY;
+import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.VALIDATOR_CONF_REG_PATH;
+import static org.wso2.carbon.identity.x509Certificate.validation.X509CertificateValidationConstants.VALIDATOR_CONF_RETRY_COUNT;
+import static org.wso2.carbon.identity.x509Certificate.validation.constant.error.ErrorMessage.ERROR_CERTIFICATE_DOES_NOT_EXIST;
+import static org.wso2.carbon.registry.core.RegistryConstants.PATH_SEPARATOR;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationException;
+import org.wso2.carbon.identity.x509Certificate.validation.constant.error.ErrorMessage;
+import org.wso2.carbon.identity.x509Certificate.validation.exception.CertificateValidationManagementClientException;
+import org.wso2.carbon.identity.x509Certificate.validation.exception.CertificateValidationManagementException;
+import org.wso2.carbon.identity.x509Certificate.validation.internal.CertValidationDataHolder;
+import org.wso2.carbon.identity.x509Certificate.validation.model.CACertificate;
+import org.wso2.carbon.identity.x509Certificate.validation.model.CACertificateInfo;
+import org.wso2.carbon.identity.x509Certificate.validation.model.Validator;
+import org.wso2.carbon.identity.x509Certificate.validation.persistence.CertificateValidationPersistenceManager;
+import org.wso2.carbon.identity.x509Certificate.validation.util.CertificateValidationManagementExceptionHandler;
+import org.wso2.carbon.registry.core.Collection;
+import org.wso2.carbon.registry.core.Registry;
+import org.wso2.carbon.registry.core.Resource;
+import org.wso2.carbon.registry.core.exceptions.RegistryException;
+import org.wso2.carbon.user.api.UserStoreException;
+
+/**
+ * This implementation handles the keystore storage/persistence related logics in the Registry.
+ */
+public class RegistryCertificateValidationPersistenceManager implements CertificateValidationPersistenceManager {
+
+    private static final Log LOG = LogFactory.getLog(RegistryCertificateValidationPersistenceManager.class);
+    private static final String REGISTRY_PATH_SEPARATOR = "/";
+
+    public static Registry getGovernanceRegistry(String tenantDomain) throws CertificateValidationException {
+
+        Registry registry;
+        try {
+            registry = CertValidationDataHolder.getInstance().getRegistryService().getGovernanceSystemRegistry(
+                    CertValidationDataHolder.getInstance().getRealmService().getTenantManager()
+                            .getTenantId(tenantDomain));
+        } catch (UserStoreException | RegistryException e) {
+            throw new CertificateValidationException("Error while get tenant registry.", e);
+        }
+        return registry;
+    }
+
+    private static List<CACertificate> getCACertsFromRegResource(String caRegPath) throws RegistryException,
+            CertificateValidationException {
+
+        List<CACertificate> caCertificateList = new ArrayList<>();
+        //get tenant registry for loading validator configurations
+        Registry registry = getGovernanceRegistry(
+                PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain());
+
+        if (registry.resourceExists(caRegPath)) {
+            Collection collection = (Collection) registry.get(caRegPath);
+            if (collection != null) {
+                String[] children = collection.getChildren();
+                for (String child : children) {
+                    Resource resource = registry.get(child);
+                    CACertificate caCertificate = resourceToCACertObject(resource);
+                    caCertificateList.add(caCertificate);
+                }
+            }
+        }
+        return caCertificateList;
+    }
+
+    private static List<Validator> getValidatorsFromRegistryResource(Registry registry,
+                                                                     String validatorConfRegPath)
+            throws RegistryException {
+
+        List<Validator> validators = new ArrayList<>();
+        Collection collection = (Collection) registry.get(validatorConfRegPath);
+        if (collection != null) {
+            String[] children = collection.getChildren();
+            for (String child : children) {
+                Resource resource = registry.get(child);
+                validators.add(resourceToValidatorObject(resource));
+            }
+        }
+
+        return validators;
+    }
+
+    private static Validator getEnabledValidatorFromRegistryResource(Registry registry, String validatorConfRegPath)
+            throws RegistryException {
+
+        Resource resource = registry.get(validatorConfRegPath);
+        return resourceToValidatorObject(resource);
+    }
+
+    private static Validator updateValidatorInRegistryResource(Registry registry, String validatorConfRegPath,
+                                                               Validator validator)
+            throws RegistryException {
+
+        Resource resource = registry.get(validatorConfRegPath);
+
+        resource.setProperty(VALIDATOR_CONF_ENABLE, Boolean.toString(validator.isEnabled()));
+        resource.setProperty(VALIDATOR_CONF_PRIORITY, Integer.toString(validator.getPriority()));
+        resource.setProperty(VALIDATOR_CONF_FULL_CHAIN_VALIDATION,
+                Boolean.toString(validator.isFullChainValidationEnabled()));
+        resource.setProperty(VALIDATOR_CONF_RETRY_COUNT, Integer.toString(validator.getRetryCount()));
+        registry.put(validatorConfRegPath, resource);
+        return validator;
+    }
+
+    private static CACertificate addCACertificateInRegistry(Registry registry, String caCertRegPath,
+                                                            X509Certificate certificate,
+                                                            List<Validator> validators)
+            throws CertificateValidationException {
+
+        List<String> ocspUrls = new ArrayList<>();
+        List<String> crlUrls = new ArrayList<>();
+        try {
+            boolean isSelfSignedCert = isSelfSignedCert(certificate);
+            for (Validator validator : validators) {
+                if (validator.isEnabled()) {
+                    if (OCSP_VALIDATOR.equals(validator.getDisplayName()) &&
+                            !isSelfSignedCert) {
+                        ocspUrls = getAIALocations(certificate);
+                    } else if (CRL_VALIDATOR.equals(validator.getDisplayName()) &&
+                            !isSelfSignedCert) {
+                        crlUrls = getCRLUrls(certificate);
+                    }
+                }
+            }
+            Resource resource = registry.newResource();
+            StringBuilder crlUrlReg = new StringBuilder();
+            if (CollectionUtils.isNotEmpty(crlUrls)) {
+                for (String crlUrl : crlUrls) {
+                    crlUrlReg.append(crlUrl).append(CA_CERT_REG_CRL_OCSP_SEPERATOR);
+                }
+            }
+
+            StringBuilder ocspUrlReg = new StringBuilder();
+            if (CollectionUtils.isNotEmpty(ocspUrls)) {
+                for (String ocspUrl : ocspUrls) {
+                    ocspUrlReg.append(ocspUrl).append(CA_CERT_REG_CRL_OCSP_SEPERATOR);
+                }
+            }
+            resource.addProperty(CA_CERT_REG_CRL, crlUrlReg.toString());
+            resource.addProperty(CA_CERT_REG_OCSP, ocspUrlReg.toString());
+            resource.addProperty(CERTFICATE_ID, generateCertificateHash(certificate));
+            resource.setContent(encodeCertificate(certificate));
+            registry.put(caCertRegPath, resource);
+            return new CACertificate(crlUrls, ocspUrls, certificate);
+        } catch (RegistryException e) {
+            throw new CertificateValidationException("Error adding default ca certificate with serial num:" +
+                    certificate.getSerialNumber() + " in registry.", e);
+        } catch (CertificateException | NoSuchAlgorithmException e) {
+            throw new CertificateValidationException("Error encoding ca certificate with serial num: " + certificate
+                    .getSerialNumber() + " to add in registry.", e);
+        }
+    }
+
+    private static CACertificate getCACertificateFromRegistry(Registry registry, String certificateId)
+            throws CertificateValidationException, RegistryException, CertificateException, NoSuchAlgorithmException,
+            CertificateValidationManagementClientException {
+
+        if (!registry.resourceExists(CA_CERT_REG_PATH)) {
+            throw new CertificateValidationException("No CA certificates found in registry.");
+        }
+
+        Collection collection = (Collection) registry.get(CA_CERT_REG_PATH);
+        if (collection == null) {
+            throw new CertificateValidationException("Invalid registry collection.");
+        }
+
+        for (String childPath : collection.getChildren()) {
+            Resource resource = registry.get(childPath);
+            String storedCertId = resource.getProperty(CERTFICATE_ID);
+
+            if (storedCertId == null) {
+                X509Certificate storedCert = decodeCertificate(new String((byte[]) resource.getContent()));
+                storedCertId = generateCertificateHash(storedCert);
+            }
+            if (certificateId.equalsIgnoreCase(storedCertId)) {
+                return resourceToCACertObject(resource);
+            }
+        }
+        throw CertificateValidationManagementExceptionHandler.handleClientException
+                (ERROR_CERTIFICATE_DOES_NOT_EXIST, certificateId,
+                        PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain());
+    }
+
+    private static CACertificate updateCACertificateInRegistry(Registry registry, String caCertRegPath,
+                                                               X509Certificate certificate, List<Validator> validators,
+                                                               String certificateId)
+            throws CertificateValidationException, RegistryException, CertificateException, NoSuchAlgorithmException {
+
+        if (!registry.resourceExists(CA_CERT_REG_PATH)) {
+            throw new CertificateValidationException("No CA certificates found in registry.");
+        }
+
+        Collection collection = (Collection) registry.get(CA_CERT_REG_PATH);
+        if (collection == null) {
+            throw new CertificateValidationException("Invalid registry collection.");
+        }
+
+        boolean certificateExists = false;
+
+        for (String childPath : collection.getChildren()) {
+            Resource resource = registry.get(childPath);
+            X509Certificate storedCert = decodeCertificate(new String((byte[]) resource.getContent()));
+
+            String storedCertId = generateCertificateHash(storedCert);
+            if (!certificateId.equalsIgnoreCase(storedCertId)) {
+                continue; // Skip non-matching certificates
+            }
+
+            certificateExists = true;
+
+            if (storedCert.getIssuerX500Principal().equals(certificate.getIssuerX500Principal())) {
+                if (storedCert.getSerialNumber().equals(certificate.getSerialNumber())) {
+                    // Update the certificate
+                    updateCertificateResource(registry, caCertRegPath, certificate, validators);
+                    return new CACertificate(getCRLUrls(certificate), getAIALocations(certificate), certificate);
+                } else {
+                    // Delete old certificate with same issuer but different serial number
+                    registry.delete(childPath);
+                    break;
+                }
+            }
+        }
+
+        // If certificate exists but was not updated (because serials didn't match)
+        if (certificateExists) {
+            updateCertificateResource(registry, caCertRegPath, certificate, validators);
+            return new CACertificate(getCRLUrls(certificate), getAIALocations(certificate), certificate);
+        }
+
+        throw new CertificateValidationException("Certificate with serial number: " + certificate.getSerialNumber() +
+                " does not exist in the registry.");
+    }
+
+    private static void updateCertificateResource(Registry registry, String caCertRegPath,
+                                                  X509Certificate certificate, List<Validator> validators)
+            throws RegistryException, CertificateException, CertificateValidationException {
+
+        boolean isSelfSigned = isSelfSignedCert(certificate);
+        List<String> crlUrls = new ArrayList<>();
+        List<String> ocspUrls = new ArrayList<>();
+
+        for (Validator validator : validators) {
+            if (!validator.isEnabled() || isSelfSigned) {
+                continue;
+            }
+
+            if (OCSP_VALIDATOR.equals(validator.getDisplayName())) {
+                ocspUrls = getAIALocations(certificate);
+            } else if (CRL_VALIDATOR.equals(validator.getDisplayName())) {
+                crlUrls = getCRLUrls(certificate);
+            }
+        }
+
+        // Create a new registry resource
+        Resource resource = registry.newResource();
+        resource.addProperty(CA_CERT_REG_CRL, String.join(CA_CERT_REG_CRL_OCSP_SEPERATOR, crlUrls));
+        resource.addProperty(CA_CERT_REG_OCSP, String.join(CA_CERT_REG_CRL_OCSP_SEPERATOR, ocspUrls));
+        resource.setContent(encodeCertificate(certificate));
+
+        registry.put(caCertRegPath, resource);
+    }
+
+    private static boolean deleteCertificateById(Registry registry, String certificateHash)
+            throws RegistryException, CertificateException, NoSuchAlgorithmException {
+
+        if (!registry.resourceExists(CA_CERT_REG_PATH)) {
+            LOG.warn("No CA certificates found in registry.");
+            return false;
+        }
+
+        Collection collection = (Collection) registry.get(CA_CERT_REG_PATH);
+        if (collection == null || collection.getChildren().length == 0) {
+            LOG.warn("No certificates available in the registry.");
+            return false;
+        }
+
+        for (String childPath : collection.getChildren()) {
+            Resource resource = registry.get(childPath);
+            X509Certificate storedCert = decodeCertificate(new String((byte[]) resource.getContent()));
+
+            String storedCertId = generateCertificateHash(storedCert);
+            if (certificateHash.equalsIgnoreCase(storedCertId)) {
+                registry.delete(childPath);
+                LOG.debug("Deleted certificate with id (hash): " + certificateHash);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String getCACertsRegPathByIssuer(String issuerDN) throws UnsupportedEncodingException {
+
+        return CA_CERT_REG_PATH + PATH_SEPARATOR + URLEncoder.encode(issuerDN, "UTF-8").replaceAll("%", ":");
+    }
+
+    private static void addValidatorsToRegistry(Registry registry, List<Validator> validators, String tenantDomain)
+            throws RegistryException {
+
+        for (Validator validator : validators) {
+            String validatorConfRegPath =
+                    VALIDATOR_CONF_REG_PATH + PATH_SEPARATOR + getNormalizedName(validator.getDisplayName());
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Adding default validator configurations to registry in: " +
+                        validatorConfRegPath);
+            }
+            try {
+                if (!registry.resourceExists(validatorConfRegPath)) {
+                    addValidatorConfigInRegistry(registry, validatorConfRegPath, validator);
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug(String.format("Validator configuration for %s is added to %s tenant registry.",
+                                validator.getDisplayName(), tenantDomain));
+                    }
+                }
+            } catch (RegistryException e) {
+                LOG.error("Error while adding validator configurations in registry.", e);
+            }
+        }
+    }
+
+    private static void addValidatorConfigInRegistry(Registry registry, String validatorConfRegPath,
+                                                     Validator validator) throws RegistryException {
+
+        Resource resource = registry.newResource();
+        resource.addProperty(VALIDATOR_CONF_NAME, validator.getName());
+        resource.addProperty(VALIDATOR_CONF_ENABLE, Boolean.toString(validator.isEnabled()));
+        resource.addProperty(VALIDATOR_CONF_PRIORITY, Integer.toString(validator.getPriority()));
+        resource.addProperty(VALIDATOR_CONF_FULL_CHAIN_VALIDATION,
+                Boolean.toString(validator.isFullChainValidationEnabled()));
+        resource.addProperty(VALIDATOR_CONF_RETRY_COUNT, Integer.toString(validator.getRetryCount()));
+        registry.put(validatorConfRegPath, resource);
+    }
+
+    public static CACertificate resourceToCACertObject(Resource resource) throws CertificateValidationException {
+
+        List<String> crlUrls;
+        List<String> ocspUrls;
+        X509Certificate x509Certificate;
+        try {
+            String crlUrlReg = resource.getProperty(CA_CERT_REG_CRL);
+            String ocspUrlReg = resource.getProperty(CA_CERT_REG_OCSP);
+            crlUrls = Arrays.asList(crlUrlReg.split(CA_CERT_REG_CRL_OCSP_SEPERATOR));
+            ocspUrls = Arrays.asList(ocspUrlReg.split(CA_CERT_REG_CRL_OCSP_SEPERATOR));
+            byte[] regContent = (byte[]) resource.getContent();
+            x509Certificate = decodeCertificate(new String(regContent));
+        } catch (RegistryException | CertificateException e) {
+            throw new CertificateValidationException("Error when converting registry resource content.", e);
+        }
+        return new CACertificate(crlUrls, ocspUrls, x509Certificate);
+    }
+
+    @Override
+    public List<Validator> getValidators(String tenantDomain) throws CertificateValidationManagementException {
+
+        try {
+            Registry registry = getGovernanceRegistry(tenantDomain);
+            if (registry.resourceExists(VALIDATOR_CONF_REG_PATH)) {
+                LOG.debug("Validator configurations are available in registry path: " + VALIDATOR_CONF_REG_PATH);
+                return getValidatorsFromRegistryResource(registry, VALIDATOR_CONF_REG_PATH);
+            } else {
+                throw CertificateValidationManagementExceptionHandler
+                        .handleClientException(ErrorMessage.ERROR_NO_VALIDATORS_CONFIGURED_ON_TENANT);
+            }
+        } catch (RegistryException | CertificateValidationException e) {
+            throw CertificateValidationManagementExceptionHandler.handleServerException
+                    (ErrorMessage.ERROR_WHILE_RETRIEVING_VALIDATORS, e);
+        }
+    }
+
+    @Override
+    public Validator getValidator(String name, String tenantDomain) throws CertificateValidationManagementException {
+
+        try {
+            Registry registry = getGovernanceRegistry(tenantDomain);
+            String validatorConfRegPath = VALIDATOR_CONF_REG_PATH + REGISTRY_PATH_SEPARATOR + name;
+            if (registry.resourceExists(validatorConfRegPath)) {
+                LOG.debug("Validator configurations are available in registry path: " + validatorConfRegPath);
+                return getEnabledValidatorFromRegistryResource(registry, validatorConfRegPath);
+            } else {
+                throw CertificateValidationManagementExceptionHandler.handleClientException
+                        (ErrorMessage.ERROR_INVALID_VALIDATOR_NAME);
+            }
+        } catch (RegistryException | CertificateValidationException e) {
+            throw CertificateValidationManagementExceptionHandler.handleServerException
+                    (ErrorMessage.ERROR_WHILE_RETRIEVING_VALIDATOR_BY_NAME, e);
+        }
+    }
+
+    @Override
+    public Validator updateValidator(Validator validator, String tenantDomain)
+            throws CertificateValidationManagementException {
+
+        try {
+            Registry registry = getGovernanceRegistry(tenantDomain);
+            String validatorConfRegPath = VALIDATOR_CONF_REG_PATH + REGISTRY_PATH_SEPARATOR + validator.getName();
+            if (registry.resourceExists(validatorConfRegPath)) {
+                LOG.debug("Validator configurations are available in registry path: " + validatorConfRegPath);
+                return updateValidatorInRegistryResource(registry, validatorConfRegPath, validator);
+            } else {
+                throw CertificateValidationManagementExceptionHandler.handleClientException
+                        (ErrorMessage.ERROR_INVALID_VALIDATOR_NAME);
+            }
+        } catch (RegistryException | CertificateValidationException e) {
+            throw CertificateValidationManagementExceptionHandler.handleServerException
+                    (ErrorMessage.ERROR_WHILE_UPDATING_VALIDATOR, e);
+        }
+    }
+
+    @Override
+    public List<CACertificateInfo> getCACertificates(String tenantDomain)
+            throws CertificateValidationManagementException {
+
+        try {
+            Registry registry = getGovernanceRegistry(tenantDomain);
+            String caRegPath = CA_CERT_REG_PATH;
+            if (registry.resourceExists(caRegPath)) {
+                LOG.debug("CA Certificate configurations are available in registry path: " + caRegPath);
+                List<CACertificateInfo> caCertificateList = new ArrayList<>();
+                Collection collection = (Collection) registry.get(caRegPath);
+                if (collection != null) {
+                    String[] children = collection.getChildren();
+                    for (String child : children) {
+                        Resource resource = registry.get(child);
+                        CACertificate caCertificate = resourceToCACertObject(resource);
+                        X509Certificate x509Cert = caCertificate.getX509Certificate();
+
+                        String certId = resource.getProperty(CERTFICATE_ID);
+
+                        if (certId == null) {
+                            certId = generateCertificateHash(x509Cert);
+                        }
+
+                        CACertificateInfo caCertificateInfo = new CACertificateInfo();
+                        caCertificateInfo.setCertId(certId);
+                        caCertificateInfo.setIssuerDN(getNormalizedName(x509Cert.getIssuerX500Principal().getName()));
+                        caCertificateInfo.setSerialNumber(getNormalizedName(x509Cert.getSerialNumber().toString(16))); // Use Hex
+                        caCertificateInfo.setCrlUrls(caCertificate.getCrlUrl());
+                        caCertificateInfo.setOcspUrls(caCertificate.getOcspUrl());
+
+                        caCertificateList.add(caCertificateInfo);
+                    }
+                }
+                return caCertificateList;
+            } else {
+                throw CertificateValidationManagementExceptionHandler.handleClientException
+                        (ErrorMessage.ERROR_NO_CA_CERTIFICATES_CONFIGURED_ON_TENANT);
+            }
+        } catch (CertificateValidationException | RegistryException | NoSuchAlgorithmException e) {
+            throw CertificateValidationManagementExceptionHandler.handleServerException
+                    (ErrorMessage.ERROR_WHILE_RETRIEVING_CA_CERTIFICATES, e);
+        }
+    }
+
+    @Override
+    public CACertificateInfo addCACertificate(String encodedCertificate, String tenantDomain)
+            throws CertificateValidationManagementException {
+
+        try {
+            Registry registry = getGovernanceRegistry(tenantDomain);
+            X509Certificate caCertificate = decodeCertificate(encodedCertificate);
+            String caCertRegPath = getCACertRegFullPath(caCertificate);
+            if (!registry.resourceExists(caCertRegPath)) {
+                CACertificate addedCACertificate = addCACertificateInRegistry(registry, caCertRegPath,
+                        caCertificate,
+                        getValidators(tenantDomain));
+                CACertificateInfo caCertificateInfo = new CACertificateInfo();
+                caCertificateInfo.setCertId(generateCertificateHash(addedCACertificate.getX509Certificate()));
+                caCertificateInfo.setIssuerDN(
+                        getNormalizedName(addedCACertificate.getX509Certificate().getIssuerDN().getName()));
+                caCertificateInfo.setSerialNumber(getNormalizedName(addedCACertificate.getX509Certificate()
+                        .getSerialNumber().toString()));
+                caCertificateInfo.setCrlUrls(addedCACertificate.getCrlUrl());
+                caCertificateInfo.setOcspUrls(addedCACertificate.getOcspUrl());
+                return caCertificateInfo;
+            } else {
+                throw CertificateValidationManagementExceptionHandler.handleClientException
+                        (ErrorMessage.ERROR_CA_CERTIFICATE_ALREADY_EXISTS);
+            }
+        } catch (UnsupportedEncodingException | CertificateValidationException | RegistryException |
+                 CertificateException | NoSuchAlgorithmException e) {
+            throw CertificateValidationManagementExceptionHandler.handleServerException
+                    (ErrorMessage.ERROR_WHILE_ADDING_CA_CERTIFICATE, e);
+        }
+    }
+
+    @Override
+    public CACertificateInfo getCACertificate(String certificateId, String tenantDomain)
+            throws CertificateValidationManagementException {
+
+        try {
+            CACertificate certificate = getCACertificateFromRegistry(getGovernanceRegistry(tenantDomain),
+                    certificateId);
+            CACertificateInfo caCertificateInfo = new CACertificateInfo();
+            caCertificateInfo.setCertId(certificateId);
+            caCertificateInfo.setIssuerDN(
+                    getNormalizedName(certificate.getX509Certificate().getIssuerDN().getName()));
+            caCertificateInfo.setSerialNumber(getNormalizedName(certificate.getX509Certificate()
+                    .getSerialNumber().toString()));
+            caCertificateInfo.setCrlUrls(certificate.getCrlUrl());
+            caCertificateInfo.setOcspUrls(certificate.getOcspUrl());
+            return caCertificateInfo;
+        } catch (CertificateValidationException | RegistryException | CertificateException |
+                 NoSuchAlgorithmException e) {
+            throw CertificateValidationManagementExceptionHandler.handleServerException
+                    (ErrorMessage.ERROR_WHILE_RETRIEVING_CA_CERTIFICATE_BY_ID, e);
+        }
+    }
+
+    @Override
+    public CACertificateInfo updateCACertificate(String certificateId, String encodedCertificate, String tenantDomain)
+            throws
+            CertificateValidationManagementException {
+
+        try {
+            Registry registry = getGovernanceRegistry(tenantDomain);
+            X509Certificate certificate = decodeCertificate(encodedCertificate);
+            String caCertRegPath = getCACertRegFullPath(certificate);
+            CACertificate caCertificate = updateCACertificateInRegistry(registry, caCertRegPath, certificate,
+                    getValidators(tenantDomain), certificateId);
+            CACertificateInfo caCertificateInfo = new CACertificateInfo();
+            caCertificateInfo.setCertId(certificateId);
+            caCertificateInfo.setIssuerDN(
+                    getNormalizedName(caCertificate.getX509Certificate().getIssuerDN().getName()));
+            caCertificateInfo.setSerialNumber(getNormalizedName(caCertificate.getX509Certificate()
+                    .getSerialNumber().toString()));
+            caCertificateInfo.setCrlUrls(caCertificate.getCrlUrl());
+            caCertificateInfo.setOcspUrls(caCertificate.getOcspUrl());
+            return caCertificateInfo;
+        } catch (UnsupportedEncodingException | CertificateValidationException | RegistryException |
+                 CertificateException | NoSuchAlgorithmException e) {
+            throw CertificateValidationManagementExceptionHandler.handleServerException
+                    (ErrorMessage.ERROR_WHILE_UPDATING_CA_CERTIFICATE, e);
+        }
+    }
+
+    @Override
+    public void deleteCACertificate(String certificateId, String tenantDomain)
+            throws CertificateValidationManagementException {
+
+        try {
+            Registry registry = getGovernanceRegistry(tenantDomain);
+            if (!deleteCertificateById(registry, certificateId)) {
+                throw CertificateValidationManagementExceptionHandler.handleClientException
+                        (ErrorMessage.ERROR_CERTIFICATE_DOES_NOT_EXIST);
+            }
+        } catch (CertificateValidationException | RegistryException |
+                 CertificateException | NoSuchAlgorithmException e) {
+            throw CertificateValidationManagementExceptionHandler.handleServerException
+                    (ErrorMessage.ERROR_WHILE_DELETING_CA_CERTIFICATE, e);
+        }
+    }
+
+    @Override
+    public List<CACertificate> getCACertsByIssuer(String issuerDN, String tenantDomain)
+            throws CertificateValidationManagementException {
+
+        try {
+            return getCACertsFromRegResource(getCACertsRegPathByIssuer(issuerDN));
+        } catch (RegistryException | CertificateValidationException | UnsupportedEncodingException e) {
+            throw CertificateValidationManagementExceptionHandler.handleServerException
+                    (ErrorMessage.ERROR_WHILE_RETIREVING_CA_CERTIFICATE_BY_ISSUER, e, issuerDN, tenantDomain);
+        }
+    }
+
+    @Override
+    public void addValidators(List<Validator> validators, String tenatDomain)
+            throws CertificateValidationManagementException {
+
+        try {
+            addValidatorsToRegistry(getGovernanceRegistry(tenatDomain), validators, tenatDomain);
+        } catch (RegistryException | CertificateValidationException e) {
+            throw CertificateValidationManagementExceptionHandler.handleServerException
+                    (ErrorMessage.ERROR_WHILE_ADDING_VALIDATORS, e, tenatDomain);
+        }
+    }
+
+    @Override
+    public void addCACertificates(List<Validator> validators, List<X509Certificate> trustedCertificates,
+                                  String tenantDomain) throws CertificateValidationManagementException {
+
+        for (X509Certificate certificate : trustedCertificates) {
+            String caCertRegPath = null;
+            try {
+                caCertRegPath = getCACertRegFullPath(certificate);
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("CA certificate registry path: " + caCertRegPath);
+                }
+                addCACertificateInRegistry(getGovernanceRegistry(tenantDomain), caCertRegPath, certificate, validators);
+            } catch (UnsupportedEncodingException | CertificateValidationException e) {
+                throw CertificateValidationManagementExceptionHandler.handleServerException
+                        (ErrorMessage.ERROR_WHILE_ADDING_CA_CERTIFICATES, e, tenantDomain);
+            }
+        }
+    }
+}

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/service/CertificateValidationManagementServiceImpl.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/service/CertificateValidationManagementServiceImpl.java
@@ -18,196 +18,74 @@
 
 package org.wso2.carbon.identity.x509Certificate.validation.service;
 
-import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_RESOURCES_DOES_NOT_EXISTS;
-import static org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationUtil.addCertificateInConfigurationStore;
-import static org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationUtil.decodeCertificate;
-import static org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationUtil.deleteCACertificateFromCertificateManager;
-import static org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationUtil.deleteCertificateInConfigurationStoreByCertificateId;
-import static org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationUtil.getCACertificateInfo;
-import static org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationUtil.getCertificateFromConfigurationStoreByCertificateId;
-import static org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationUtil.getCertificateListFromConfigurationStore;
-import static org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationUtil.getNormalizedName;
-import static org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationUtil.getValidatorFromConfigStoreByName;
-import static org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationUtil.getValidatorsFromConfigStore;
-import static org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationUtil.updateCACertificateInCertificateManager;
-import static org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationUtil.updateCertificateInConfigurationStoreByCertificateId;
-import static org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationUtil.updateValidatorInConfigStore;
-import java.security.cert.CertificateException;
-import java.security.cert.X509Certificate;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
-import org.wso2.carbon.identity.certificate.management.exception.CertificateMgtException;
-import org.wso2.carbon.identity.configuration.mgt.core.exception.ConfigurationManagementException;
-import org.wso2.carbon.identity.x509Certificate.validation.CertificateValidationException;
-import org.wso2.carbon.identity.x509Certificate.validation.constant.error.ErrorMessage;
 import org.wso2.carbon.identity.x509Certificate.validation.exception.CertificateValidationManagementException;
-import org.wso2.carbon.identity.x509Certificate.validation.model.CACertificate;
 import org.wso2.carbon.identity.x509Certificate.validation.model.CACertificateInfo;
-import org.wso2.carbon.identity.x509Certificate.validation.model.CertObject;
 import org.wso2.carbon.identity.x509Certificate.validation.model.Validator;
-import org.wso2.carbon.identity.x509Certificate.validation.util.CertificateValidationManagementExceptionHandler;
+import org.wso2.carbon.identity.x509Certificate.validation.persistence.CertificateValidationPersistenceManager;
+import org.wso2.carbon.identity.x509Certificate.validation.persistence.CertificateValidationPersistenceManagerFactory;
 
 /**
- * This implementation handles the x509 authenticator validator manager implementation.
+ * This implementation handles the certificate validation management operations.
  */
 public class CertificateValidationManagementServiceImpl implements CertificateValidationManagementService {
+
+
+    private static final CertificateValidationPersistenceManager certificateValidationPersistenceManager =
+            CertificateValidationPersistenceManagerFactory.getX509CertificatePersistenceManager();
 
     @Override
     public List<Validator> getValidators(String tenantDomain) throws CertificateValidationManagementException {
 
-        try {
-            return getValidatorsFromConfigStore(tenantDomain);
-        } catch (ConfigurationManagementException e) {
-            if (ERROR_CODE_RESOURCES_DOES_NOT_EXISTS.getCode().equals(e.getErrorCode())) {
-                return new ArrayList<>();
-            }
-            throw CertificateValidationManagementExceptionHandler
-                    .handleServerException(ErrorMessage.ERROR_WHILE_RETRIEVING_VALIDATORS, e);
-        }
+        return certificateValidationPersistenceManager.getValidators(tenantDomain);
     }
 
     @Override
     public Validator getValidator(String name, String tenantDomain) throws CertificateValidationManagementException {
 
-        try {
-            name = name.toLowerCase();
-            Optional<Validator> validator = getValidatorFromConfigStoreByName(tenantDomain, name);
-
-            if (!validator.isPresent()) {
-                throw CertificateValidationManagementExceptionHandler
-                        .handleClientException(ErrorMessage.ERROR_INVALID_VALIDATOR_NAME, name, tenantDomain);
-            }
-            return validator.get();
-        } catch (CertificateValidationException e) {
-            throw CertificateValidationManagementExceptionHandler
-                    .handleServerException(ErrorMessage.ERROR_WHILE_RETRIEVING_VALIDATOR_BY_NAME, e);
-        }
+        return certificateValidationPersistenceManager.getValidator(name, tenantDomain);
     }
 
     @Override
     public Validator updateValidator(Validator validator, String tenantDomain)
             throws CertificateValidationManagementException {
 
-        try {
-            Optional<Validator> updatedValidator = updateValidatorInConfigStore(tenantDomain, validator);
-            if (!updatedValidator.isPresent()) {
-                throw CertificateValidationManagementExceptionHandler
-                        .handleClientException(ErrorMessage.ERROR_INVALID_VALIDATOR_NAME, validator.getName(),
-                                tenantDomain);
-            }
-            return updatedValidator.get();
-        } catch (CertificateValidationException e) {
-            throw CertificateValidationManagementExceptionHandler
-                    .handleServerException(ErrorMessage.ERROR_WHILE_UPDATING_VALIDATOR, e);
-        }
+        return certificateValidationPersistenceManager.updateValidator(validator, tenantDomain);
     }
 
     @Override
     public List<CACertificateInfo> getCACertificates(String tenantDomain)
             throws CertificateValidationManagementException {
 
-        try {
-            Optional<List<CACertificateInfo>> caCertificateInfoList =
-                    getCertificateListFromConfigurationStore(tenantDomain);
-            return caCertificateInfoList.orElseGet(ArrayList::new);
-        } catch (CertificateValidationException e) {
-            throw CertificateValidationManagementExceptionHandler
-                    .handleServerException(ErrorMessage.ERROR_WHILE_RETRIEVING_CA_CERTIFICATES, e);
-        }
+        return certificateValidationPersistenceManager.getCACertificates(tenantDomain);
     }
 
     @Override
     public CACertificateInfo addCACertificate(String encodedCertificate, String tenantDomain)
             throws CertificateValidationManagementException {
 
-        try {
-            X509Certificate caCertificate = decodeCertificate(encodedCertificate);
-            Optional<CertObject> certObject = addCertificateInConfigurationStore(tenantDomain, caCertificate);
-            if (!certObject.isPresent()) {
-                throw CertificateValidationManagementExceptionHandler
-                        .handleClientException(ErrorMessage.ERROR_NO_CA_CERTIFICATES_CONFIGURED_ON_TENANT,
-                                tenantDomain);
-            }
-            return getCACertificateInfo(caCertificate, certObject.get());
-        } catch (CertificateValidationException | CertificateException | CertificateMgtException e) {
-            throw CertificateValidationManagementExceptionHandler
-                    .handleServerException(ErrorMessage.ERROR_WHILE_ADDING_CA_CERTIFICATE, e);
-        }
+        return certificateValidationPersistenceManager.addCACertificate(encodedCertificate, tenantDomain);
     }
 
     @Override
     public CACertificateInfo getCACertificate(String certificateId, String tenantDomain)
             throws CertificateValidationManagementException {
 
-        try {
-            Optional<CACertificate> caCertificate =
-                    getCertificateFromConfigurationStoreByCertificateId(tenantDomain, certificateId);
-            if (!caCertificate.isPresent()) {
-                throw CertificateValidationManagementExceptionHandler
-                        .handleClientException(ErrorMessage.ERROR_CERTIFICATE_DOES_NOT_EXIST, certificateId,
-                                tenantDomain);
-            }
-            CACertificateInfo caCertificateInfo = new CACertificateInfo();
-            caCertificateInfo.setCertId(certificateId);
-            caCertificateInfo.setIssuerDN(getNormalizedName(caCertificate.get()
-                    .getX509Certificate().getIssuerDN().getName()));
-            caCertificateInfo.setSerialNumber(getNormalizedName(caCertificate.get().getX509Certificate()
-                    .getSerialNumber().toString()));
-            caCertificateInfo.setCrlUrls(caCertificate.get().getCrlUrl());
-            caCertificateInfo.setOcspUrls(caCertificate.get().getOcspUrl());
-            return caCertificateInfo;
-        } catch (CertificateValidationException e) {
-            throw CertificateValidationManagementExceptionHandler
-                    .handleServerException(ErrorMessage.ERROR_WHILE_RETRIEVING_CA_CERTIFICATE_BY_ID, e);
-        }
+        return certificateValidationPersistenceManager.getCACertificate(certificateId, tenantDomain);
     }
 
     @Override
     public CACertificateInfo updateCACertificate(String certificateId, String encodedCertificate, String tenantDomain)
             throws CertificateValidationManagementException {
 
-        try {
-            X509Certificate certificate = decodeCertificate(encodedCertificate);
-            Optional<CertObject> certObject =
-                    updateCertificateInConfigurationStoreByCertificateId(certificateId, certificate, tenantDomain);
-            if (!certObject.isPresent()) {
-                throw CertificateValidationManagementExceptionHandler
-                        .handleClientException(ErrorMessage.ERROR_CERTIFICATE_DOES_NOT_EXIST, certificateId,
-                                tenantDomain);
-            }
-            X509Certificate updatedCertificate = updateCACertificateInCertificateManager(certificateId,
-                    certificate, tenantDomain);
-            CACertificateInfo caCertificateInfo = new CACertificateInfo();
-            caCertificateInfo.setCertId(certificateId);
-            caCertificateInfo.setIssuerDN(getNormalizedName(updatedCertificate.getIssuerDN().getName()));
-            caCertificateInfo.setSerialNumber(getNormalizedName(updatedCertificate.getSerialNumber().toString()));
-            caCertificateInfo.setCrlUrls(certObject.get().getCrlUrls());
-            caCertificateInfo.setOcspUrls(certObject.get().getOcspUrls());
-            return caCertificateInfo;
-        } catch (CertificateValidationException | CertificateException e) {
-            throw CertificateValidationManagementExceptionHandler
-                    .handleServerException(ErrorMessage.ERROR_WHILE_UPDATING_CA_CERTIFICATE, e);
-        }
+        return certificateValidationPersistenceManager.updateCACertificate(certificateId, encodedCertificate,
+                tenantDomain);
     }
 
     @Override
     public void deleteCACertificate(String certificateId, String tenantDomain)
             throws CertificateValidationManagementException {
 
-        try {
-            Optional<CertObject> certObject =
-                    deleteCertificateInConfigurationStoreByCertificateId(certificateId, tenantDomain);
-            if (certObject.isPresent()) {
-                deleteCACertificateFromCertificateManager(certificateId, tenantDomain);
-            } else {
-                throw CertificateValidationManagementExceptionHandler
-                        .handleClientException(ErrorMessage.ERROR_CERTIFICATE_DOES_NOT_EXIST, certificateId,
-                                tenantDomain);
-            }
-        } catch (CertificateValidationException e) {
-            throw CertificateValidationManagementExceptionHandler
-                    .handleServerException(ErrorMessage.ERROR_WHILE_DELETING_CA_CERTIFICATE, e);
-        }
+        certificateValidationPersistenceManager.deleteCACertificate(certificateId, tenantDomain);
     }
 }


### PR DESCRIPTION
### Purpose
- https://github.com/wso2/product-is/issues/22729

This pull request introduces several changes to the X509 Certificate Validation component, focusing on adding new error messages, enhancing the `CertObject` model, and implementing a new persistence manager interface and its hybrid implementation.

### Enhancements to Error Handling:
* Added new error messages for various certificate validation operations in the `ErrorMessage` enum. [[1]](diffhunk://#diff-c12dae3117b45f5c7645fc8daf9050615cc6ce94c69f1d2ecd6d0600e766af61R35-R36) [[2]](diffhunk://#diff-c12dae3117b45f5c7645fc8daf9050615cc6ce94c69f1d2ecd6d0600e766af61L52-R60)

### Model Updates:
* Added a new field `certificatePersistedId` to the `CertObject` class and provided getter and setter methods for it. [[1]](diffhunk://#diff-8f216467241f66310c3b4e0d1118c932191fb8a9686fa87f057b134ab4de4d29R33) [[2]](diffhunk://#diff-8f216467241f66310c3b4e0d1118c932191fb8a9686fa87f057b134ab4de4d29R75-R84)

### Persistence Manager Interface:
* Introduced a new `CertificateValidationPersistenceManager` interface to handle persistence/storage logic for certificates and validators.

### Hybrid Persistence Manager Implementation:
* Implemented the `HybridCertificateValidationPersistenceManager` class, which combines JDBC and Registry-based persistence managers to manage certificate validation.

### Factory for Persistence Manager:
* Added a factory class `CertificateValidationPersistenceManagerFactory` to instantiate the appropriate persistence manager based on configuration.