### PR TITLE
add certificate existing check for trustore certs add

### DIFF
--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/persistence/impl/RegistryCertificateValidationPersistenceManager.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/persistence/impl/RegistryCertificateValidationPersistenceManager.java
@@ -320,8 +320,11 @@ public class RegistryCertificateValidationPersistenceManager implements Certific
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("CA certificate registry path: " + caCertRegPath);
                 }
-                addCACertificateInRegistry(getGovernanceRegistry(tenantDomain), caCertRegPath, certificate, validators);
-            } catch (UnsupportedEncodingException | CertificateValidationException e) {
+                if (!getGovernanceRegistry(tenantDomain).resourceExists(caCertRegPath)) {
+                    addCACertificateInRegistry(getGovernanceRegistry(tenantDomain), caCertRegPath, certificate,
+                            validators);
+                }
+            } catch (UnsupportedEncodingException | CertificateValidationException | RegistryException e) {
                 throw CertificateValidationManagementExceptionHandler.handleServerException
                         (ErrorMessage.ERROR_WHILE_ADDING_CA_CERTIFICATES, e, tenantDomain);
             }
@@ -544,7 +547,7 @@ public class RegistryCertificateValidationPersistenceManager implements Certific
     }
 
     private static CACertificate updateCertificateResource(Registry registry, String caCertRegPath,
-                                                  X509Certificate certificate, List<Validator> validators)
+                                                           X509Certificate certificate, List<Validator> validators)
             throws RegistryException, CertificateException, CertificateValidationException {
 
         boolean isSelfSigned = isSelfSignedCert(certificate);


### PR DESCRIPTION
## Purpose
- https://github.com/wso2/product-is/issues/22729

This pull request makes an important change to the `addCACertificates` method in the `RegistryCertificateValidationPersistenceManager` class to improve error handling and prevent duplicate entries.

Error handling and validation improvements:

* [`components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/persistence/impl/RegistryCertificateValidationPersistenceManager.java`](diffhunk://#diff-3a2d461f403fdd35350cb7e9145df612cdfaebd198c06bbeb7dc708670861c78L323-R327): Modified the `addCACertificates` method to check if the CA certificate registry path already exists before adding a new CA certificate, and added `RegistryException` to the catch block to handle additional potential errors.