### PR TITLE
Fixed hybrid mode issues

### DIFF
--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/CertificateValidationUtil.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/CertificateValidationUtil.java
@@ -319,6 +319,7 @@ public class CertificateValidationUtil {
 
         Validator validator = new Validator();
         validator.setDisplayName(((ResourceImpl) resource).getName());
+        validator.setName(resource.getProperty(VALIDATOR_CONF_NAME));
         validator.setEnabled(Boolean.parseBoolean(resource.getProperty(VALIDATOR_CONF_ENABLE)));
         validator.setPriority(Integer.parseInt(resource.getProperty(VALIDATOR_CONF_PRIORITY)));
         validator.setFullChainValidationEnabled(

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/persistence/impl/HybridCertificateValidationPersistenceManager.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/persistence/impl/HybridCertificateValidationPersistenceManager.java
@@ -90,7 +90,7 @@ public class HybridCertificateValidationPersistenceManager implements Certificat
         try {
             return jdbcCertificateValidationPersistenceManager.getValidator(name, tenantDomain);
         } catch (CertificateValidationManagementException e) {
-            if (!ERROR_INVALID_VALIDATOR_NAME.getCode().equals(e.getErrorCode())) {
+            if (ERROR_INVALID_VALIDATOR_NAME.getCode().equals(e.getErrorCode())) {
                 return registryCertificateValidationPersistenceManager.getValidator(name, tenantDomain);
             } else {
                 throw e;
@@ -105,7 +105,7 @@ public class HybridCertificateValidationPersistenceManager implements Certificat
         try {
             return jdbcCertificateValidationPersistenceManager.updateValidator(validator, tenantDomain);
         } catch (CertificateValidationManagementException e) {
-            if (!ERROR_INVALID_VALIDATOR_NAME.getCode().equals(e.getErrorCode())) {
+            if (ERROR_INVALID_VALIDATOR_NAME.getCode().equals(e.getErrorCode())) {
                 return registryCertificateValidationPersistenceManager.updateValidator(validator, tenantDomain);
             } else {
                 throw e;

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/persistence/impl/HybridCertificateValidationPersistenceManager.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/persistence/impl/HybridCertificateValidationPersistenceManager.java
@@ -20,8 +20,6 @@ package org.wso2.carbon.identity.x509Certificate.validation.persistence.impl;
 
 import static org.wso2.carbon.identity.x509Certificate.validation.constant.error.ErrorMessage.ERROR_CERTIFICATE_DOES_NOT_EXIST;
 import static org.wso2.carbon.identity.x509Certificate.validation.constant.error.ErrorMessage.ERROR_INVALID_VALIDATOR_NAME;
-import static org.wso2.carbon.identity.x509Certificate.validation.constant.error.ErrorMessage.ERROR_NO_CA_CERTIFICATES_CONFIGURED_ON_TENANT;
-import static org.wso2.carbon.identity.x509Certificate.validation.constant.error.ErrorMessage.ERROR_NO_VALIDATORS_CONFIGURED_ON_TENANT;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -51,14 +49,9 @@ public class HybridCertificateValidationPersistenceManager implements Certificat
     public void addValidators(List<Validator> validators, String tenatDomain)
             throws CertificateValidationManagementException {
 
-        try {
-            registryCertificateValidationPersistenceManager.getValidators(tenatDomain);
-        } catch (CertificateValidationManagementException e) {
-            if (ERROR_NO_VALIDATORS_CONFIGURED_ON_TENANT.getCode().equals(e.getErrorCode())) {
-                jdbcCertificateValidationPersistenceManager.addValidators(validators, tenatDomain);
-            } else {
-                throw e;
-            }
+        List<Validator> existingValidators = registryCertificateValidationPersistenceManager.getValidators(tenatDomain);
+        if (existingValidators.isEmpty()) {
+            jdbcCertificateValidationPersistenceManager.addValidators(validators, tenatDomain);
         }
     }
 
@@ -66,16 +59,8 @@ public class HybridCertificateValidationPersistenceManager implements Certificat
     public void addCACertificates(List<Validator> validators, List<X509Certificate> trustedCertificates,
                                   String tenantDomain) throws CertificateValidationManagementException {
 
-        try {
-            registryCertificateValidationPersistenceManager.getCACertificates(tenantDomain);
-        } catch (CertificateValidationManagementException e) {
-            if (ERROR_NO_CA_CERTIFICATES_CONFIGURED_ON_TENANT.getCode().equals(e.getErrorCode())) {
-                jdbcCertificateValidationPersistenceManager.addCACertificates(validators, trustedCertificates,
-                        tenantDomain);
-            } else {
-                throw e;
-            }
-        }
+        jdbcCertificateValidationPersistenceManager.addCACertificates(validators, trustedCertificates,
+                tenantDomain);
     }
 
     @Override

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/persistence/impl/JDBCCertificateValidationPersistenceManager.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/persistence/impl/JDBCCertificateValidationPersistenceManager.java
@@ -150,7 +150,7 @@ public class JDBCCertificateValidationPersistenceManager implements CertificateV
             Optional<Validator> updatedValidator = updateValidatorInConfigStore(tenantDomain, validator);
             if (!updatedValidator.isPresent()) {
                 throw CertificateValidationManagementExceptionHandler
-                        .handleClientException(ErrorMessage.ERROR_INVALID_VALIDATOR_NAME, validator.getName(),
+                        .handleClientException(ErrorMessage.ERROR_INVALID_VALIDATOR_NAME, validator.getDisplayName(),
                                 tenantDomain);
             }
             return updatedValidator.get();
@@ -701,7 +701,8 @@ public class JDBCCertificateValidationPersistenceManager implements CertificateV
             if (existingCertObject != null) {
                 // Case 2: Cert ID exists under the same issuer → Update the certificate
                 updatedCertObject.setCertificatePersistedId(existingCertObject.getCertificatePersistedId());
-                updateCACertificateInCertificateManager(certificateId, certificate, tenantDomain);
+                updateCACertificateInCertificateManager(updatedCertObject.getCertificatePersistedId(), certificate,
+                        tenantDomain);
                 certList.set(certIndex, updatedCertObject);
             } else {
                 // Case 3: Cert ID does not exist under this issuer → Add as a new cert
@@ -1155,14 +1156,14 @@ public class JDBCCertificateValidationPersistenceManager implements CertificateV
             if (certObjects != null) {
                 for (CertObject certObject : certObjects) {
                     // Extract details from the CertObject
-                    String certId = certObject.getCertId();
                     List<String> crlUrls = certObject.getCrlUrls();
                     List<String> ocspUrls = certObject.getOcspUrls();
 
                     Certificate certificate = CertValidationDataHolder.getInstance()
                             .getCertificateManagementService()
-                            .getCertificate(certId, PrivilegedCarbonContext.getThreadLocalCarbonContext()
-                                    .getTenantDomain());
+                            .getCertificate(certObject.getCertificatePersistedId(),
+                                    PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                                            .getTenantDomain());
 
                     X509Certificate x509Certificate = decodeCertificate(certificate.getCertificateContent());
 

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/persistence/impl/RegistryCertificateValidationPersistenceManager.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/persistence/impl/RegistryCertificateValidationPersistenceManager.java
@@ -49,6 +49,7 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.logging.Log;
@@ -106,7 +107,7 @@ public class RegistryCertificateValidationPersistenceManager implements Certific
                 return getEnabledValidatorFromRegistryResource(registry, validatorConfRegPath);
             } else {
                 throw CertificateValidationManagementExceptionHandler.handleClientException
-                        (ErrorMessage.ERROR_INVALID_VALIDATOR_NAME);
+                        (ErrorMessage.ERROR_INVALID_VALIDATOR_NAME, name, tenantDomain);
             }
         } catch (RegistryException | CertificateValidationException e) {
             throw CertificateValidationManagementExceptionHandler.handleServerException
@@ -127,7 +128,7 @@ public class RegistryCertificateValidationPersistenceManager implements Certific
                 return updateValidatorInRegistryResource(registry, validatorConfRegPath, validator);
             } else {
                 throw CertificateValidationManagementExceptionHandler.handleClientException
-                        (ErrorMessage.ERROR_INVALID_VALIDATOR_NAME);
+                        (ErrorMessage.ERROR_INVALID_VALIDATOR_NAME, validator.getDisplayName(), tenantDomain);
             }
         } catch (RegistryException | CertificateValidationException e) {
             throw CertificateValidationManagementExceptionHandler.handleServerException
@@ -659,8 +660,10 @@ public class RegistryCertificateValidationPersistenceManager implements Certific
         try {
             String crlUrlReg = resource.getProperty(CA_CERT_REG_CRL);
             String ocspUrlReg = resource.getProperty(CA_CERT_REG_OCSP);
-            crlUrls = Arrays.asList(crlUrlReg.split(CA_CERT_REG_CRL_OCSP_SEPERATOR));
-            ocspUrls = Arrays.asList(ocspUrlReg.split(CA_CERT_REG_CRL_OCSP_SEPERATOR));
+            crlUrls = crlUrlReg.isEmpty() ? Collections.emptyList() :
+                    Arrays.asList(crlUrlReg.split(CA_CERT_REG_CRL_OCSP_SEPERATOR));
+            ocspUrls = ocspUrlReg.isEmpty() ? Collections.emptyList() :
+                    Arrays.asList(ocspUrlReg.split(CA_CERT_REG_CRL_OCSP_SEPERATOR));
             byte[] regContent = (byte[]) resource.getContent();
             x509Certificate = decodeCertificate(new String(regContent));
         } catch (RegistryException | CertificateException e) {


### PR DESCRIPTION
## Purpose
- https://github.com/wso2/product-is/issues/22729

This pull request includes several updates to the certificate validation persistence management system. The changes focus on improving error handling, refining method logic, and ensuring proper resource management.

### Error Handling Improvements:
* [`components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/persistence/impl/JDBCCertificateValidationPersistenceManager.java`](diffhunk://#diff-d049e1341c18c555cf8d1b69075ec7ce525a46b8f993e467b7663a5b9c7df42bR454-R456): Added checks for `ERROR_CODE_RESOURCE_DOES_NOT_EXISTS` in multiple methods to handle cases where resources do not exist. [[1]](diffhunk://#diff-d049e1341c18c555cf8d1b69075ec7ce525a46b8f993e467b7663a5b9c7df42bR454-R456) [[2]](diffhunk://#diff-d049e1341c18c555cf8d1b69075ec7ce525a46b8f993e467b7663a5b9c7df42bR552-R554) [[3]](diffhunk://#diff-d049e1341c18c555cf8d1b69075ec7ce525a46b8f993e467b7663a5b9c7df42bR579-R581) [[4]](diffhunk://#diff-d049e1341c18c555cf8d1b69075ec7ce525a46b8f993e467b7663a5b9c7df42bL716-R739) [[5]](diffhunk://#diff-d049e1341c18c555cf8d1b69075ec7ce525a46b8f993e467b7663a5b9c7df42bL1156-R1187)

### Method Logic Refinements:
* [`components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/CertificateValidationUtil.java`](diffhunk://#diff-55affdc3c415ffdec6febc41eff867b88d7a2fd1f4dc2d73e3840a6c4e177e26R322): Added `validator.setName(resource.getProperty(VALIDATOR_CONF_NAME))` to ensure the validator's name is set correctly.
* [`components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/persistence/impl/HybridCertificateValidationPersistenceManager.java`](diffhunk://#diff-6cd4b203c4265647f54b8f8ccd2003996c24f58efe1ccaa3548e96bb5efa8621L54-L78): Refined the logic in `addValidators` and `addCACertificates` methods to simplify the flow and remove unnecessary exception handling.
* [`components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/persistence/impl/HybridCertificateValidationPersistenceManager.java`](diffhunk://#diff-6cd4b203c4265647f54b8f8ccd2003996c24f58efe1ccaa3548e96bb5efa8621L108-R93): Corrected the condition in `getValidator` and `updateValidator` methods to handle `ERROR_INVALID_VALIDATOR_NAME` properly. [[1]](diffhunk://#diff-6cd4b203c4265647f54b8f8ccd2003996c24f58efe1ccaa3548e96bb5efa8621L108-R93) [[2]](diffhunk://#diff-6cd4b203c4265647f54b8f8ccd2003996c24f58efe1ccaa3548e96bb5efa8621L123-R108)

### Resource Management:
* [`components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/persistence/impl/JDBCCertificateValidationPersistenceManager.java`](diffhunk://#diff-d049e1341c18c555cf8d1b69075ec7ce525a46b8f993e467b7663a5b9c7df42bR597-R607): Added `try-catch` blocks in `getValidatorsFromConfigStore` and `getCACertsFromConfigStore` methods to handle resource retrieval errors and ensure proper resource management. [[1]](diffhunk://#diff-d049e1341c18c555cf8d1b69075ec7ce525a46b8f993e467b7663a5b9c7df42bR597-R607) [[2]](diffhunk://#diff-d049e1341c18c555cf8d1b69075ec7ce525a46b8f993e467b7663a5b9c7df42bL1100-L1108)

### Minor Fixes:
* [`components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/persistence/impl/RegistryCertificateValidationPersistenceManager.java`](diffhunk://#diff-3a2d461f403fdd35350cb7e9145df612cdfaebd198c06bbeb7dc708670861c78L109-R110): Updated error messages to include more context, such as validator name and tenant domain. [[1]](diffhunk://#diff-3a2d461f403fdd35350cb7e9145df612cdfaebd198c06bbeb7dc708670861c78L109-R110) [[2]](diffhunk://#diff-3a2d461f403fdd35350cb7e9145df612cdfaebd198c06bbeb7dc708670861c78L130-R131)
* [`components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/persistence/impl/RegistryCertificateValidationPersistenceManager.java`](diffhunk://#diff-3a2d461f403fdd35350cb7e9145df612cdfaebd198c06bbeb7dc708670861c78L662-R666): Adjusted the handling of CRL and OCSP URLs to return empty lists if the URLs are empty.