### PR TITLE
Updated the validator name while updating th validator object

### DIFF
--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/persistence/impl/JDBCCertificateValidationPersistenceManager.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/persistence/impl/JDBCCertificateValidationPersistenceManager.java
@@ -985,6 +985,9 @@ public class JDBCCertificateValidationPersistenceManager implements CertificateV
     private static void createAttributeList(Validator validator, Resource resource) {
 
         List<Attribute> attributes = new ArrayList<>();
+        if (validator.getName() == null) {
+            validator.setName(resourceToValidatorObject(resource).getName());
+        }
         attributes.add(new Attribute(VALIDATOR_CONF_NAME, validator.getName()));
         attributes.add(new Attribute(VALIDATOR_CONF_ENABLE,
                 Boolean.toString(validator.isEnabled())));

--- a/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/persistence/impl/RegistryCertificateValidationPersistenceManager.java
+++ b/components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/persistence/impl/RegistryCertificateValidationPersistenceManager.java
@@ -397,6 +397,7 @@ public class RegistryCertificateValidationPersistenceManager implements Certific
 
         Resource resource = registry.get(validatorConfRegPath);
 
+        resource.setProperty(VALIDATOR_CONF_NAME, resourceToValidatorObject(resource).getName());
         resource.setProperty(VALIDATOR_CONF_ENABLE, Boolean.toString(validator.isEnabled()));
         resource.setProperty(VALIDATOR_CONF_PRIORITY, Integer.toString(validator.getPriority()));
         resource.setProperty(VALIDATOR_CONF_FULL_CHAIN_VALIDATION,


### PR DESCRIPTION
## Purpose
- https://github.com/wso2/product-is/issues/23267

This pull request includes changes to the `JDBCCertificateValidationPersistenceManager` and `RegistryCertificateValidationPersistenceManager` classes to ensure that the `name` attribute of a `Validator` is properly set when creating and updating resources.

### Improvements to Validator attribute handling:

* [`components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/persistence/impl/JDBCCertificateValidationPersistenceManager.java`](diffhunk://#diff-d049e1341c18c555cf8d1b69075ec7ce525a46b8f993e467b7663a5b9c7df42bR988-R990): Added a check to set the `name` attribute of a `Validator` if it is null when creating the attribute list.
* [`components/validation/src/main/java/org/wso2/carbon/identity/x509Certificate/validation/persistence/impl/RegistryCertificateValidationPersistenceManager.java`](diffhunk://#diff-3a2d461f403fdd35350cb7e9145df612cdfaebd198c06bbeb7dc708670861c78R400): Ensured that the `name` attribute of a `Validator` is set in the resource properties when updating a validator.