### PR TITLE
Provide support for url-encoded PEM certificates in X509CertificateAuthenticationValve

### DIFF
--- a/components/valve/src/main/java/org/wso2/carbon/extension/identity/x509Certificate/valve/X509CertificateAuthenticationValve.java
+++ b/components/valve/src/main/java/org/wso2/carbon/extension/identity/x509Certificate/valve/X509CertificateAuthenticationValve.java
@@ -115,7 +115,7 @@ public class X509CertificateAuthenticationValve extends ValveBase {
     /**
      * Decode the certificate based on the value of the x509RequestHeaderEncoded configuration.
      *
-     * @param pemCert PEM formatted url-encoded certificate.
+     * @param pemCert PEM formatted URL-encoded certificate.
      * @return Decoded certificate if x509RequestHeaderEncoded is true, else return the original certificate.
      */
     private String getDecodedCertificate(String pemCert) {
@@ -123,8 +123,8 @@ public class X509CertificateAuthenticationValve extends ValveBase {
         String decodedCert = pemCert;
         if (X509ServerConfiguration.getInstance().isX509RequestHeaderEncoded()) {
             try {
-                decodedCert = URLDecoder.decode(pemCert, StandardCharsets.UTF_8.name()).trim();
-            } catch (UnsupportedEncodingException e) {
+                decodedCert = URLDecoder.decode(pemCert, StandardCharsets.UTF_8).trim();
+            } catch (IllegalArgumentException e) {
                 log.error("Error occurred while decoding the certificate", e);
             }
         }

--- a/components/valve/src/main/java/org/wso2/carbon/extension/identity/x509Certificate/valve/config/X509ServerConfiguration.java
+++ b/components/valve/src/main/java/org/wso2/carbon/extension/identity/x509Certificate/valve/config/X509ServerConfiguration.java
@@ -36,8 +36,10 @@ public class X509ServerConfiguration {
     private static final X509ServerConfiguration INSTANCE = new X509ServerConfiguration();
     private static final String CONFIG_ELEM_X509 = "X509";
     private static final String CONFIG_ELEM_X509_REQUEST_HEADER = "X509RequestHeaderName";
+    private static final String CONFIG_ELEM_X509_REQUEST_HEADER_ENCODED = "X509RequestHeaderEncoded";
 
     private String x509requestHeader = "X-SSL-CERT";
+    private boolean x509RequestHeaderEncoded = false;
 
     private X509ServerConfiguration() {
 
@@ -58,6 +60,16 @@ public class X509ServerConfiguration {
     public String getX509requestHeader() {
 
         return x509requestHeader;
+    }
+
+    /**
+     * Check whether the x509 request header is encoded according to the identity xml configuration value.
+     *
+     * @return true if the X509 request header is encoded
+     */
+    public boolean isX509RequestHeaderEncoded() {
+
+        return x509RequestHeaderEncoded;
     }
 
     private void buildX509ServerConfiguration() {
@@ -83,6 +95,12 @@ public class X509ServerConfiguration {
                 x509Elem.getFirstChildWithName(getQNameWithIdentityNS(CONFIG_ELEM_X509_REQUEST_HEADER));
         if (requestHeaderName != null) {
             x509requestHeader = requestHeaderName.getText().trim();
+        }
+
+        OMElement requestHeaderEncodedElem =
+                x509Elem.getFirstChildWithName(getQNameWithIdentityNS(CONFIG_ELEM_X509_REQUEST_HEADER_ENCODED));
+        if (requestHeaderEncodedElem != null) {
+            x509RequestHeaderEncoded = Boolean.parseBoolean(requestHeaderEncodedElem.getText().trim());
         }
     }
 

--- a/components/valve/src/main/java/org/wso2/carbon/extension/identity/x509Certificate/valve/config/X509ServerConfiguration.java
+++ b/components/valve/src/main/java/org/wso2/carbon/extension/identity/x509Certificate/valve/config/X509ServerConfiguration.java
@@ -53,9 +53,9 @@ public class X509ServerConfiguration {
     }
 
     /**
-     * Get the name of the x509 request header according to the identity xml configuration value.
+     * Get the name of the X.509 request header according to the identity xml configuration value.
      *
-     * @return name of the X509 request header
+     * @return name of the X.509 request header
      */
     public String getX509requestHeader() {
 
@@ -63,9 +63,9 @@ public class X509ServerConfiguration {
     }
 
     /**
-     * Check whether the x509 request header is encoded according to the identity xml configuration value.
+     * Check whether the X.509 request header is encoded according to the identity xml configuration value.
      *
-     * @return true if the X509 request header is encoded
+     * @return true if the X.509 request header is encoded
      */
     public boolean isX509RequestHeaderEncoded() {
 


### PR DESCRIPTION
This pull request adds support for handling URL-encoded X.509 certificate request headers in the X509 Certificate Authentication Valve. It introduces a new configuration option to indicate whether the incoming certificate header is URL-encoded and decodes it accordingly before processing.

**Support for URL-encoded certificate headers:**

* Added a new configuration property, `X509RequestHeaderEncoded`, to the `X509ServerConfiguration` class and XML configuration, allowing administrators to specify if the X.509 certificate header is URL-encoded. 
* Implemented logic in `X509CertificateAuthenticationValve` to decode the certificate header using `URLDecoder` if the new configuration property is set to `true`. 
* Added the `isX509RequestHeaderEncoded()` method to expose the configuration value and updated the class to handle the new property.

### Related issue
- https://github.com/wso2/product-is/issues/25683